### PR TITLE
Accept renamed <applicability> element on KERs (2022-Q3 schema)

### DIFF
--- a/AOP-Wiki_XML_to_RDF_conversion.py
+++ b/AOP-Wiki_XML_to_RDF_conversion.py
@@ -1180,7 +1180,9 @@ for ker in root.findall(aopxml + 'key-event-relationship'):
     kerdict[ker.get('id')]['aopo:has_downstream_key_event'] = {}
     kerdict[ker.get('id')]['aopo:has_downstream_key_event']['id'] = ker.find(aopxml + 'title').find(aopxml + 'downstream-id').text
     kerdict[ker.get('id')]['aopo:has_downstream_key_event']['dc:identifier'] = 'aop.events:' + refs['KE'][ker.find(aopxml + 'title').find(aopxml + 'downstream-id').text]
-    for appl in ker.findall(aopxml + 'taxonomic-applicability'):
+    # AOP-Wiki renamed <taxonomic-applicability> to <applicability> on KERs in the
+    # 2022-Q3 XML schema. Both names are accepted so historical snapshots round-trip.
+    for appl in (ker.findall(aopxml + 'applicability') + ker.findall(aopxml + 'taxonomic-applicability')):
         for sex in appl.findall(aopxml + 'sex'):
             if 'pato:0000047' not in kerdict[ker.get('id')]:
                 kerdict[ker.get('id')]['pato:0000047'] = [[sex.find(aopxml + 'evidence').text, sex.find(aopxml + 'sex').text]]

--- a/src/aopwiki_rdf/parser/xml_parser.py
+++ b/src/aopwiki_rdf/parser/xml_parser.py
@@ -606,7 +606,9 @@ def parse_aopwiki_xml(xml_path: str, config: PipelineConfig = None) -> ParsedEnt
         kerdict[ker.get('id')]['aopo:has_downstream_key_event'] = {}
         kerdict[ker.get('id')]['aopo:has_downstream_key_event']['id'] = ker.find(aopxml + 'title').find(aopxml + 'downstream-id').text
         kerdict[ker.get('id')]['aopo:has_downstream_key_event']['dc:identifier'] = 'aop.events:' + refs['KE'][ker.find(aopxml + 'title').find(aopxml + 'downstream-id').text]
-        for appl in ker.findall(aopxml + 'taxonomic-applicability'):
+        # AOP-Wiki renamed <taxonomic-applicability> to <applicability> on KERs in the
+        # 2022-Q3 XML schema. Both names are accepted so historical snapshots round-trip.
+        for appl in (ker.findall(aopxml + 'applicability') + ker.findall(aopxml + 'taxonomic-applicability')):
             for sex in appl.findall(aopxml + 'sex'):
                 if 'pato:0000047' not in kerdict[ker.get('id')]:
                     kerdict[ker.get('id')]['pato:0000047'] = [[sex.find(aopxml + 'evidence').text, sex.find(aopxml + 'sex').text]]


### PR DESCRIPTION
## Summary

AOP-Wiki renamed the KER applicability wrapper element from `<taxonomic-applicability>` to `<applicability>` in the 2022-Q3 XML schema. The KER parser was still looking for the old element name, silently dropping ~900 triples per snapshot (sex, life-stage, taxonomy) since 2022-07.

This patch accepts both element names so historical snapshots round-trip.

## Root cause

Both `<aop>` and `<key-event>` handlers were updated to use the new bare `<applicability>` element at the schema change. The `<key-event-relationship>` handler was missed:

- `src/aopwiki_rdf/parser/xml_parser.py:609` — production parser
- `AOP-Wiki_XML_to_RDF_conversion.py:1183` — legacy flat script

## Impact

- ~900 KER triples (sex / life-stage / taxonomy) silently dropped per snapshot
- Affected every quarterly conversion from **2022-07** onward (≈15 snapshots × ~900 triples)
- Cascades to every downstream consumer: the SPARQL endpoints at `aopwiki-multirdf.vhp4safety.nl` and `aopwiki.rdf.bigcat-bioinformatics.org`, and dashboard plots that touch KER applicability

## Round-trip verification

Patched parser run against the source XML for each era:

| XML snapshot | KERs | sex | life | taxon | wrapper element |
|---|---:|---:|---:|---:|---|
| 2022-04 | 1 579 | 274 | 269 | 362 | `<taxonomic-applicability>` (old) — matches existing TTL exactly |
| 2022-07 | 1 636 | 279 | 274 | 367 | `<applicability>` (new) — previously 0/0/0 |
| 2024-01 | 1 951 | 408 | 399 | 495 | `<applicability>` |
| 2026-04 | 2 310 | 549 | 532 | 634 | `<applicability>` |

The 2022-04 numbers match the rdflib ground truth from the pre-fix TTL, confirming the patch is a true superset of the old behaviour — pre-2022-Q3 conversions still produce identical RDF.

## Test plan

- [x] Round-trip both old and new schema XMLs through the patched parser
- [x] Verify pre-fix TTL counts match patched-parser output on pre-2022-Q3 XMLs
- [x] Re-convert all 16 affected snapshots (2022-07 → 2026-04) end-to-end via the multi-endpoint Setup pipeline — 16/16 PASS, recovered triples consistent across the timeline