### PR TITLE
Gate weekly RDF publish against BERN2-degraded data

### DIFF
--- a/.github/workflows/rdfgeneration.yml
+++ b/.github/workflows/rdfgeneration.yml
@@ -132,6 +132,37 @@ jobs:
           echo "Remaining files in data/:"
           ls -la data/ | head -10
 
+      # Step 7b: Publish gate -- block degraded data from reaching master (QC-02)
+      # The pipeline degrades BERN2 NER to regex when the BERN2 host is down
+      # (ner_fallback_on_failure), which can silently halve gene associations.
+      # Generation would otherwise commit that degraded output before the
+      # post-commit QC delta guard ever runs. This gate compares the freshly
+      # generated data/ against the CURRENTLY committed data (HEAD:data/, i.e.
+      # last week's known-good) and FAILS the job BEFORE the commit step if the
+      # gene-association or total-triple count drops more than 5%. On breach,
+      # "Commit and Push" is skipped and master retains the good data until
+      # BERN2 recovers. Reuses scripts/qc_delta_guard.py (rdflib is installed
+      # in Step 4). HEAD:data/ is available at default fetch-depth.
+      - name: Publish gate (delta vs current master)
+        run: |
+          echo "=== Publish gate (QC-02): new data/ vs committed HEAD:data/ ==="
+          mkdir -p publish-baseline
+          missing=false
+          for f in AOPWikiRDF.ttl AOPWikiRDF-Genes.ttl; do
+            if git cat-file -e "HEAD:data/$f" 2>/dev/null; then
+              git show "HEAD:data/$f" > "publish-baseline/$f"
+            else
+              echo "No HEAD:data/$f committed; cannot gate on it."
+              missing=true
+            fi
+          done
+          if [ "$missing" = true ]; then
+            echo "::warning::Skipping publish gate -- no committed baseline (first run?)."
+            exit 0
+          fi
+          python scripts/qc_delta_guard.py --new-dir data/ --baseline-dir publish-baseline/ --drop-pct 0.05
+          rm -rf publish-baseline
+
       # Step 8: Check if there are changes
       - id: check_changes
         name: Check for Changes


### PR DESCRIPTION
Closes #86.

Adds a **pre-commit publish gate** to `rdfgeneration.yml`. After generation writes `data/` and before "Commit and Push", it compares the new output against the currently committed data (`HEAD:data/`, last-known-good) via `scripts/qc_delta_guard.py --drop-pct 0.05`. On a >5% gene-association or total-triple drop the job fails **before** committing, so a BERN2-outage morning can't replace the live enriched data with regex-only output. `master` keeps the good data until BERN2 recovers.

Verified locally with real data objects:
- Healthy run (190k triples / 12,390 gene assoc, new == baseline) -> **PASS** (exit 0, commit proceeds).
- Simulated BERN2 outage (144k / 8,163, -34% genes) -> **FAIL** (exit 1, commit blocked):
  `gene associations dropped -34.12% (12390 -> 8163), exceeds 5.0% threshold`.

Complements the post-commit QC delta guard (#83) as defense-in-depth: this one prevents the bad publish, that one alarms on anything that slips through.