### PR TITLE
Enable BERN2 in test-conversion to match production (parity)

### DIFF
--- a/.github/workflows/test-python-conversion.yml
+++ b/.github/workflows/test-python-conversion.yml
@@ -20,7 +20,9 @@ on:
 jobs:
   test-conversion:
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    # Job ceiling must exceed the 90-min conversion step plus the compare/
+    # validate/upload steps; matches the generation job's 120.
+    timeout-minutes: 120
 
     steps:
       # Step 1: Checkout repository
@@ -70,13 +72,21 @@ jobs:
           fi
 
       # Step 6: Run Python conversion script (test version)
+      # Must mirror the production command in rdfgeneration.yml, which runs with
+      # --enable-bern2. Without it this regression test exercised only the regex
+      # gene-mapping path and never the BERN2 NER+EL path that production now
+      # depends on -- and the comparison below pitted non-BERN2 test output
+      # against BERN2-enriched production, so it "differed" every week and the
+      # signal was meaningless. The committed data/cache/bern2/ cache keeps this
+      # warm (only the partial-chunk/failed-lookup tail re-queries), so it stays
+      # within the time budget; timeout raised 60->90 to match generation.
       - id: python-conversion
         name: Run Python Conversion Script
-        timeout-minutes: 60
+        timeout-minutes: 90
         run: |
-          echo "Running Python conversion script..."
-          python run_conversion.py --output-dir data-test/ --log-level INFO
-          
+          echo "Running Python conversion script (BERN2 enabled, matching production)..."
+          python run_conversion.py --output-dir data-test/ --log-level INFO --enable-bern2
+
           echo "Generated files:"
           ls -lh data-test/
         shell: bash


### PR DESCRIPTION
Closes #88.

`test-python-conversion.yml` ran the converter **without** `--enable-bern2` while production runs **with** it, so the weekly regression test never exercised the BERN2 NER+EL path production depends on, and its comparison pitted non-BERN2 test output against BERN2-enriched production (a meaningless 'differs significantly' every week).

Changes:
- Add `--enable-bern2` to the conversion command so it mirrors `rdfgeneration.yml`.
- The committed `data/cache/bern2/` cache (and the cache the 08:00 generation commits an hour earlier) keeps it warm; only the partial-chunk/failed-lookup tail re-queries.
- Raise the conversion step timeout 60->90 and the job timeout 90->120 to match generation's budget.

Now test output and production output are both BERN2-enriched, so the comparison is apples-to-apples and the test actually guards the BERN2 path.