### PR TITLE
ci: bump actions/setup-python to v6 (Node 24)

### DIFF
--- a/.github/workflows/Turtle_File_Quality_Control.yml
+++ b/.github/workflows/Turtle_File_Quality_Control.yml
@@ -27,7 +27,7 @@ jobs:
 
       # Step 2: Set up Python
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/rdfgeneration-jupyter-backup.yml
+++ b/.github/workflows/rdfgeneration-jupyter-backup.yml
@@ -21,7 +21,7 @@ jobs:
       # Step 2: Set up Python
       - id: python
         name: Python Setup
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           

--- a/.github/workflows/rdfgeneration.yml
+++ b/.github/workflows/rdfgeneration.yml
@@ -21,7 +21,7 @@ jobs:
       # Step 2: Set up Python
       - id: python
         name: Python Setup
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           

--- a/.github/workflows/shacl-validation.yml
+++ b/.github/workflows/shacl-validation.yml
@@ -22,7 +22,7 @@ jobs:
 
       # Step 2: Set up Python
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/test-python-conversion.yml
+++ b/.github/workflows/test-python-conversion.yml
@@ -35,7 +35,7 @@ jobs:
       # Step 2: Set up Python
       - id: python
         name: Python Setup
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           

--- a/.github/workflows/uri-resolvability-check.yml
+++ b/.github/workflows/uri-resolvability-check.yml
@@ -30,7 +30,7 @@ jobs:
       
       # Step 2: Set up Python
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       


### PR DESCRIPTION
Follow-up to #91. `actions/setup-python@v5` still targets Node 20, which GitHub now force-runs on Node 24 while emitting a deprecation warning. `@v6` is the Node 24 release — bumping it across the workflows clears the remaining warning. (`actions/checkout@v5` is already current and no longer flagged.)