### PR TITLE
ci: bump actions/cache to v5 and upload-artifact to v7 (Node 24)

### DIFF
--- a/.github/workflows/rdfgeneration-jupyter-backup.yml
+++ b/.github/workflows/rdfgeneration-jupyter-backup.yml
@@ -27,7 +27,7 @@ jobs:
           
       # Step 3: Cache pip dependencies
       - name: Cache pip dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}

--- a/.github/workflows/rdfgeneration.yml
+++ b/.github/workflows/rdfgeneration.yml
@@ -27,7 +27,7 @@ jobs:
           
       # Step 3: Cache pip dependencies
       - name: Cache pip dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
@@ -194,7 +194,7 @@ jobs:
 
       # Step 10: Upload RDF artifacts
       - name: Upload RDF Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: rdf-files
           path: |

--- a/.github/workflows/shacl-validation.yml
+++ b/.github/workflows/shacl-validation.yml
@@ -37,7 +37,7 @@ jobs:
       # Step 5: Upload validation artifacts
       - name: Upload Validation Artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: shacl-validation-reports-${{ github.run_number }}
           path: |

--- a/.github/workflows/test-python-conversion.yml
+++ b/.github/workflows/test-python-conversion.yml
@@ -41,7 +41,7 @@ jobs:
           
       # Step 3: Cache pip dependencies
       - name: Cache pip dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
@@ -227,7 +227,7 @@ jobs:
 
       # Step 10: Upload test artifacts
       - name: Upload Test Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-rdf-files
           path: |
@@ -239,7 +239,7 @@ jobs:
       # Step 11: Upload production backup for comparison
       - name: Upload Production Backup Files
         if: ${{ inputs.compare_with_production == 'true' || github.event_name == 'schedule' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: production-rdf-backup
           path: |
@@ -294,7 +294,7 @@ jobs:
       # Step 13: Upload comparison report
       - name: Upload Comparison Report
         if: ${{ inputs.compare_with_production == 'true' || github.event_name == 'schedule' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: comparison-report
           path: comparison_report.md

--- a/.github/workflows/uri-resolvability-check.yml
+++ b/.github/workflows/uri-resolvability-check.yml
@@ -36,7 +36,7 @@ jobs:
       
       # Step 3: Cache pip dependencies
       - name: Cache pip dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
@@ -133,7 +133,7 @@ jobs:
       
       # Step 8: Upload artifacts
       - name: Upload Test Reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: uri-test-reports-${{ github.run_number }}
           path: |


### PR DESCRIPTION
Follow-up to #91 / #92. After bumping checkout and setup-python, the URI Resolvability run surfaced the remaining Node 20 actions: `actions/cache@v4` and `actions/upload-artifact@v4`. GitHub now force-runs both on Node 24 with a deprecation warning.

- `actions/cache@v4` -> `@v5` (4 usages)
- `actions/upload-artifact@v4` -> `@v7` (6 usages)

Only the stable inputs are used — `name`/`path`/`retention-days` for upload-artifact (v7's new `archive`/direct-upload is opt-in; default behavior unchanged) and `path`/`key`/`restore-keys` for cache — so the bump is non-breaking. This clears the last Node 20 deprecation warnings across all workflows.