### PR TITLE
feat(parser): multi-version XML compatibility + VoID endpoint override

### DIFF
--- a/src/aopwiki_rdf/config.py
+++ b/src/aopwiki_rdf/config.py
@@ -22,6 +22,11 @@ class PipelineConfig:
         "&col=gd_prev_sym&col=gd_aliases&col=gd_pub_acc_ids"
         "&col=md_ensembl_id&status=Approved&format=text&submit=submit"
     )
+    # VoID metadata advertisement. Defaults match the production endpoint and
+    # data dump; deployments serving the data elsewhere (e.g. the versioned
+    # multi-endpoint) override these so per-version VoID points at their host.
+    sparql_endpoint: str = "https://aopwiki.rdf.bigcat-bioinformatics.org/sparql/"
+    data_dump_base: str = "https://raw.githubusercontent.com/marvinm2/AOPWikiRDF/master/data"
     max_retries: int = 3
     request_timeout: int = 30
     log_level: str = "INFO"

--- a/src/aopwiki_rdf/parser/xml_parser.py
+++ b/src/aopwiki_rdf/parser/xml_parser.py
@@ -26,6 +26,19 @@ AOPXML_NS = '{http://www.aopkb.org/aop-xml}'
 HTML_TAG_PATTERN = re.compile(r'<[^>]+>')
 
 
+def _get_ke_id(element):
+    """Resolve key event ID from element regardless of XML schema version.
+
+    Pre-2022-07-01 XML uses the 'id' attribute for key-event elements inside
+    AOP sections. Post-2022-07-01 uses 'key-event-id'. Standalone key-event
+    elements always use 'id' across all versions.
+    """
+    ke_id = element.get('key-event-id')
+    if ke_id is None:
+        ke_id = element.get('id')
+    return ke_id
+
+
 @dataclass
 class ParsedEntities:
     """Container for all entity dictionaries extracted from AOP-Wiki XML."""
@@ -116,29 +129,42 @@ def parse_aopwiki_xml(xml_path: str, config: PipelineConfig = None) -> ParsedEnt
         aopdict[AOP.get('id')]['dc:identifier'] = 'aop:' + refs['AOP'][AOP.get('id')]
         aopdict[AOP.get('id')]['rdfs:label'] = '"AOP ' + refs['AOP'][AOP.get('id')] + '"'
         aopdict[AOP.get('id')]['foaf:page'] = '<https://identifiers.org/aop/' + refs['AOP'][AOP.get('id')] + '>'
-        aopdict[AOP.get('id')]['dc:title'] = '"' + AOP.find(aopxml + 'title').text + '"'
-        aopdict[AOP.get('id')]['dcterms:alternative'] = AOP.find(aopxml + 'short-name').text
+        title_elem = AOP.find(aopxml + 'title')
+        aopdict[AOP.get('id')]['dc:title'] = '"' + (title_elem.text if title_elem is not None and title_elem.text else '') + '"'
+        short_name_elem = AOP.find(aopxml + 'short-name')
+        aopdict[AOP.get('id')]['dcterms:alternative'] = short_name_elem.text if short_name_elem is not None else None
         aopdict[AOP.get('id')]['dc:description'] = []
         if AOP.find(aopxml + 'background') is not None:
             if AOP.find(aopxml + 'background').text is not None:
                 aopdict[AOP.get('id')]['dc:description'].append('"""' + HTML_TAG_PATTERN.sub('', AOP.find(aopxml + 'background').text) + '"""')
-        if AOP.find(aopxml + 'authors').text is not None:
-            aopdict[AOP.get('id')]['dc:creator'] = '"""' + HTML_TAG_PATTERN.sub('', AOP.find(aopxml + 'authors').text) + '"""'
-        if AOP.find(aopxml + 'abstract').text is not None:
-            aopdict[AOP.get('id')]['dcterms:abstract'] = '"""' + HTML_TAG_PATTERN.sub('', AOP.find(aopxml + 'abstract').text) + '"""'
-        if AOP.find(aopxml + 'status').find(aopxml + 'wiki-status') is not None:
-            aopdict[AOP.get('id')]['dcterms:accessRights'] = '"' + AOP.find(aopxml + 'status').find(aopxml + 'wiki-status').text + '"'
-        if AOP.find(aopxml + 'status').find(aopxml + 'oecd-status') is not None:
-            aopdict[AOP.get('id')]['oecd-status'] = '"' + AOP.find(aopxml + 'status').find(aopxml + 'oecd-status').text + '"'
-        if AOP.find(aopxml + 'status').find(aopxml + 'saaop-status') is not None:
-            aopdict[AOP.get('id')]['saaop-status'] = '"' + AOP.find(aopxml + 'status').find(aopxml + 'saaop-status').text + '"'
-        wiki_license_el = AOP.find(aopxml + 'status').find(aopxml + 'wiki-license')
-        if wiki_license_el is not None and wiki_license_el.text:
-            aopdict[AOP.get('id')]['_wiki_license'] = wiki_license_el.text
-        aopdict[AOP.get('id')]['oecd-project'] = AOP.find(aopxml + 'oecd-project').text
-        aopdict[AOP.get('id')]['dc:source'] = AOP.find(aopxml + 'source').text
-        aopdict[AOP.get('id')]['dcterms:created'] = AOP.find(aopxml + 'creation-timestamp').text
-        aopdict[AOP.get('id')]['dcterms:modified'] = AOP.find(aopxml + 'last-modification-timestamp').text
+        authors_elem = AOP.find(aopxml + 'authors')
+        if authors_elem is not None and authors_elem.text is not None:
+            aopdict[AOP.get('id')]['dc:creator'] = '"""' + HTML_TAG_PATTERN.sub('', authors_elem.text) + '"""'
+        abstract_elem = AOP.find(aopxml + 'abstract')
+        if abstract_elem is not None and abstract_elem.text is not None:
+            aopdict[AOP.get('id')]['dcterms:abstract'] = '"""' + HTML_TAG_PATTERN.sub('', abstract_elem.text) + '"""'
+        status_elem = AOP.find(aopxml + 'status')
+        if status_elem is not None:
+            wiki_status = status_elem.find(aopxml + 'wiki-status')
+            if wiki_status is not None:
+                aopdict[AOP.get('id')]['dcterms:accessRights'] = '"' + wiki_status.text + '"'
+            oecd_status = status_elem.find(aopxml + 'oecd-status')
+            if oecd_status is not None:
+                aopdict[AOP.get('id')]['oecd-status'] = '"' + oecd_status.text + '"'
+            saaop_status = status_elem.find(aopxml + 'saaop-status')
+            if saaop_status is not None:
+                aopdict[AOP.get('id')]['saaop-status'] = '"' + saaop_status.text + '"'
+            wiki_license_el = status_elem.find(aopxml + 'wiki-license')
+            if wiki_license_el is not None and wiki_license_el.text:
+                aopdict[AOP.get('id')]['_wiki_license'] = wiki_license_el.text
+        oecd_proj_elem = AOP.find(aopxml + 'oecd-project')
+        aopdict[AOP.get('id')]['oecd-project'] = oecd_proj_elem.text if oecd_proj_elem is not None else None
+        source_elem = AOP.find(aopxml + 'source')
+        aopdict[AOP.get('id')]['dc:source'] = source_elem.text if source_elem is not None else None
+        created_elem = AOP.find(aopxml + 'creation-timestamp')
+        aopdict[AOP.get('id')]['dcterms:created'] = created_elem.text if created_elem is not None else None
+        modified_elem = AOP.find(aopxml + 'last-modification-timestamp')
+        aopdict[AOP.get('id')]['dcterms:modified'] = modified_elem.text if modified_elem is not None else None
         for appl in AOP.findall(aopxml + 'applicability'):
             for sex in appl.findall(aopxml + 'sex'):
                 if 'pato:0000047' not in aopdict[AOP.get('id')]:
@@ -153,8 +179,12 @@ def parse_aopwiki_xml(xml_path: str, config: PipelineConfig = None) -> ParsedEnt
         aopdict[AOP.get('id')]['aopo:has_key_event'] = {}
         if AOP.find(aopxml + 'key-events') is not None:
             for KE in AOP.find(aopxml + 'key-events').findall(aopxml + 'key-event'):
-                aopdict[AOP.get('id')]['aopo:has_key_event'][KE.get('key-event-id')] = {}
-                aopdict[AOP.get('id')]['aopo:has_key_event'][KE.get('key-event-id')]['dc:identifier'] = 'aop.events:' + refs['KE'][KE.get('key-event-id')]
+                ke_id = _get_ke_id(KE)
+                if ke_id is None or ke_id not in refs['KE']:
+                    logger.warning(f"Skipping KE with unresolvable ID in AOP {AOP.get('id')}")
+                    continue
+                aopdict[AOP.get('id')]['aopo:has_key_event'][ke_id] = {}
+                aopdict[AOP.get('id')]['aopo:has_key_event'][ke_id]['dc:identifier'] = 'aop.events:' + refs['KE'][ke_id]
         aopdict[AOP.get('id')]['aopo:has_key_event_relationship'] = {}
         if AOP.find(aopxml + 'key-event-relationships') is not None:
             for KER in AOP.find(aopxml + 'key-event-relationships').findall(aopxml + 'relationship'):
@@ -165,40 +195,58 @@ def parse_aopwiki_xml(xml_path: str, config: PipelineConfig = None) -> ParsedEnt
                 aopdict[AOP.get('id')]['aopo:has_key_event_relationship'][KER.get('id')]['aopo:has_evidence'] = KER.find(aopxml + 'evidence').text
         aopdict[AOP.get('id')]['aopo:has_molecular_initiating_event'] = {}
         for MIE in AOP.findall(aopxml + 'molecular-initiating-event'):
-            aopdict[AOP.get('id')]['aopo:has_molecular_initiating_event'][MIE.get('key-event-id')] = {}
-            aopdict[AOP.get('id')]['aopo:has_molecular_initiating_event'][MIE.get('key-event-id')]['dc:identifier'] = 'aop.events:' + refs['KE'][MIE.get('key-event-id')]
-            aopdict[AOP.get('id')]['aopo:has_key_event'][MIE.get('key-event-id')] = {}
-            aopdict[AOP.get('id')]['aopo:has_key_event'][MIE.get('key-event-id')]['dc:identifier'] = 'aop.events:' + refs['KE'][MIE.get('key-event-id')]
-            if MIE.find(aopxml + 'evidence-supporting-chemical-initiation').text is not None:
-                kedict[MIE.get('key-event-id')] = {}
-                aopdict[AOP.get('id')]['dc:description'].append('"""' + HTML_TAG_PATTERN.sub('', MIE.find(aopxml + 'evidence-supporting-chemical-initiation').text) + '"""')
+            mie_id = _get_ke_id(MIE)
+            if mie_id is None or mie_id not in refs['KE']:
+                logger.warning(f"Skipping MIE with unresolvable ID in AOP {AOP.get('id')}")
+                continue
+            aopdict[AOP.get('id')]['aopo:has_molecular_initiating_event'][mie_id] = {}
+            aopdict[AOP.get('id')]['aopo:has_molecular_initiating_event'][mie_id]['dc:identifier'] = 'aop.events:' + refs['KE'][mie_id]
+            aopdict[AOP.get('id')]['aopo:has_key_event'][mie_id] = {}
+            aopdict[AOP.get('id')]['aopo:has_key_event'][mie_id]['dc:identifier'] = 'aop.events:' + refs['KE'][mie_id]
+            esc_elem = MIE.find(aopxml + 'evidence-supporting-chemical-initiation')
+            if esc_elem is not None and esc_elem.text is not None:
+                kedict[mie_id] = {}
+                aopdict[AOP.get('id')]['dc:description'].append('"""' + HTML_TAG_PATTERN.sub('', esc_elem.text) + '"""')
         aopdict[AOP.get('id')]['aopo:has_adverse_outcome'] = {}
         for AO in AOP.findall(aopxml + 'adverse-outcome'):
-            aopdict[AOP.get('id')]['aopo:has_adverse_outcome'][AO.get('key-event-id')] = {}
-            aopdict[AOP.get('id')]['aopo:has_adverse_outcome'][AO.get('key-event-id')]['dc:identifier'] = 'aop.events:' + refs['KE'][AO.get('key-event-id')]
-            aopdict[AOP.get('id')]['aopo:has_key_event'][AO.get('key-event-id')] = {}
-            aopdict[AOP.get('id')]['aopo:has_key_event'][AO.get('key-event-id')]['dc:identifier'] = 'aop.events:' + refs['KE'][AO.get('key-event-id')]
-            if AO.find(aopxml + 'examples').text is not None:
-                kedict[AO.get('key-event-id')] = {}
-                aopdict[AOP.get('id')]['dc:description'].append('"""' + HTML_TAG_PATTERN.sub('', AO.find(aopxml + 'examples').text) + '"""')
+            ao_id = _get_ke_id(AO)
+            if ao_id is None or ao_id not in refs['KE']:
+                logger.warning(f"Skipping AO with unresolvable ID in AOP {AOP.get('id')}")
+                continue
+            aopdict[AOP.get('id')]['aopo:has_adverse_outcome'][ao_id] = {}
+            aopdict[AOP.get('id')]['aopo:has_adverse_outcome'][ao_id]['dc:identifier'] = 'aop.events:' + refs['KE'][ao_id]
+            aopdict[AOP.get('id')]['aopo:has_key_event'][ao_id] = {}
+            aopdict[AOP.get('id')]['aopo:has_key_event'][ao_id]['dc:identifier'] = 'aop.events:' + refs['KE'][ao_id]
+            examples_elem = AO.find(aopxml + 'examples')
+            if examples_elem is not None and examples_elem.text is not None:
+                kedict[ao_id] = {}
+                aopdict[AOP.get('id')]['dc:description'].append('"""' + HTML_TAG_PATTERN.sub('', examples_elem.text) + '"""')
         aopdict[AOP.get('id')]['nci:C54571'] = {}
         if AOP.find(aopxml + 'aop-stressors') is not None:
             for stressor in AOP.find(aopxml + 'aop-stressors').findall(aopxml + 'aop-stressor'):
                 aopdict[AOP.get('id')]['nci:C54571'][stressor.get('stressor-id')] = {}
                 aopdict[AOP.get('id')]['nci:C54571'][stressor.get('stressor-id')]['dc:identifier'] = 'aop.stressor:' + refs['Stressor'][stressor.get('stressor-id')]
                 aopdict[AOP.get('id')]['nci:C54571'][stressor.get('stressor-id')]['aopo:has_evidence'] = stressor.find(aopxml + 'evidence').text
-        if AOP.find(aopxml + 'overall-assessment').find(aopxml + 'description').text is not None:
-            aopdict[AOP.get('id')]['nci:C25217'] = '"""' + HTML_TAG_PATTERN.sub('', AOP.find(aopxml + 'overall-assessment').find(aopxml + 'description').text) + '"""'
-        if AOP.find(aopxml + 'overall-assessment').find(aopxml + 'key-event-essentiality-summary').text is not None:
-            aopdict[AOP.get('id')]['nci:C48192'] = '"""' + HTML_TAG_PATTERN.sub('', AOP.find(aopxml + 'overall-assessment').find(aopxml + 'key-event-essentiality-summary').text) + '"""'
-        if AOP.find(aopxml + 'overall-assessment').find(aopxml + 'applicability').text is not None:
-            aopdict[AOP.get('id')]['aopo:AopContext'] = '"""' + HTML_TAG_PATTERN.sub('', AOP.find(aopxml + 'overall-assessment').find(aopxml + 'applicability').text) + '"""'
-        if AOP.find(aopxml + 'overall-assessment').find(aopxml + 'weight-of-evidence-summary').text is not None:
-            aopdict[AOP.get('id')]['aopo:has_evidence'] = '"""' + HTML_TAG_PATTERN.sub('', AOP.find(aopxml + 'overall-assessment').find(aopxml + 'weight-of-evidence-summary').text) + '"""'
-        if AOP.find(aopxml + 'overall-assessment').find(aopxml + 'quantitative-considerations').text is not None:
-            aopdict[AOP.get('id')]['edam:operation_3799'] = '"""' + HTML_TAG_PATTERN.sub('', AOP.find(aopxml + 'overall-assessment').find(aopxml + 'quantitative-considerations').text) + '"""'
-        if AOP.find(aopxml + 'potential-applications').text is not None:
-            aopdict[AOP.get('id')]['nci:C25725'] = '"""' + HTML_TAG_PATTERN.sub('', AOP.find(aopxml + 'potential-applications').text) + '"""'
+        overall_assessment = AOP.find(aopxml + 'overall-assessment')
+        if overall_assessment is not None:
+            oa_desc = overall_assessment.find(aopxml + 'description')
+            if oa_desc is not None and oa_desc.text is not None:
+                aopdict[AOP.get('id')]['nci:C25217'] = '"""' + HTML_TAG_PATTERN.sub('', oa_desc.text) + '"""'
+            oa_ke_ess = overall_assessment.find(aopxml + 'key-event-essentiality-summary')
+            if oa_ke_ess is not None and oa_ke_ess.text is not None:
+                aopdict[AOP.get('id')]['nci:C48192'] = '"""' + HTML_TAG_PATTERN.sub('', oa_ke_ess.text) + '"""'
+            oa_appl = overall_assessment.find(aopxml + 'applicability')
+            if oa_appl is not None and oa_appl.text is not None:
+                aopdict[AOP.get('id')]['aopo:AopContext'] = '"""' + HTML_TAG_PATTERN.sub('', oa_appl.text) + '"""'
+            oa_woe = overall_assessment.find(aopxml + 'weight-of-evidence-summary')
+            if oa_woe is not None and oa_woe.text is not None:
+                aopdict[AOP.get('id')]['aopo:has_evidence'] = '"""' + HTML_TAG_PATTERN.sub('', oa_woe.text) + '"""'
+            oa_quant = overall_assessment.find(aopxml + 'quantitative-considerations')
+            if oa_quant is not None and oa_quant.text is not None:
+                aopdict[AOP.get('id')]['edam:operation_3799'] = '"""' + HTML_TAG_PATTERN.sub('', oa_quant.text) + '"""'
+        pot_appl_elem = AOP.find(aopxml + 'potential-applications')
+        if pot_appl_elem is not None and pot_appl_elem.text is not None:
+            aopdict[AOP.get('id')]['nci:C25725'] = '"""' + HTML_TAG_PATTERN.sub('', pot_appl_elem.text) + '"""'
     logger.info(f'Completed AOP parsing: {len(aopdict)} Adverse Outcome Pathways processed')
 
     # Validate AOP required fields

--- a/src/aopwiki_rdf/pipeline.py
+++ b/src/aopwiki_rdf/pipeline.py
@@ -536,6 +536,8 @@ def _stage_write_void_rdf(config, context):
         "genes": context.get("triple_count_genes", 0),
     }
     metadata["bridgedb_url"] = config.bridgedb_url
+    metadata["sparql_endpoint"] = config.sparql_endpoint
+    metadata["data_dump_base"] = config.data_dump_base
 
     write_void_rdf(filepath + "AOPWikiRDF-Void.ttl", metadata)
 

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -49,13 +49,13 @@ def test_orchestrator_line_count():
 
     The limit is a regression guard, not a hard architectural rule -- the
     monolith (pipeline_monolith.py) is ~2,300 lines. The orchestrator has
-    grown with added stages (ARR filter, BERN2 enrichment); 600 lines
-    leaves headroom for a few more while still catching a real slide back
-    toward monolithic logic.
+    grown with added stages (ARR filter, BERN2 enrichment, VoID endpoint
+    overrides); 625 lines leaves headroom for a few more while still catching
+    a real slide back toward monolithic logic.
     """
     src = inspect.getsource(pipeline)
     line_count = len(src.splitlines())
-    assert line_count < 600, f"pipeline.py has {line_count} lines (limit: 600)"
+    assert line_count < 625, f"pipeline.py has {line_count} lines (limit: 625)"
 
 
 def test_monolith_preserved():


### PR DESCRIPTION
Closes #94.

## What
Re-applies the defensive parsing guards required to convert **pre-2022-07-01** AOP-Wiki XML, rebased onto current master so the recent #81 (KER `<applicability>`) and #82 (VoID) fixes are retained. Also adds a VoID endpoint-override hook.

### Parser (`xml_parser.py`)
- `_get_ke_id()` resolves KE ids from `key-event-id` (>=2022-07) or `id` (pre-2022-07).
- Optional AOP elements (title, short-name, authors, abstract, status block, oecd-project, source, timestamps, overall-assessment children, potential-applications) guarded against missing nodes/text.
- KE/MIE/AO entries with unresolvable ids are skipped with a warning instead of crashing.

### VoID override hook
- `PipelineConfig` gains `sparql_endpoint` / `data_dump_base`; defaults equal the current `write_void_rdf` production defaults, so output here is unchanged.
- `_stage_write_void_rdf` passes them through.

## Verification
- **Master crashes** with `KeyError: None` on 2018-04-01; this branch parses 2018→2026 cleanly (AOP/KE/KER counts sane and monotonic).
- **Output-neutral**: parsed output byte-identical to master across all 13 entity dicts on 2025-07-01.
- Unit suite: 214 passed. The 4 `test_rdf_writer` dual-predicate failures are **pre-existing on master** (skos:exactMatch/owl:sameAs migration, ref #70) and unrelated to this change. Bumped the `pipeline.py` line-count guard 600→625 for the two override lines.

## Follow-up
Tag `v2.2` on merge; the `AOP-Wiki_multi-endpoint` submodule will pin it and reconvert all versions.