### PR TITLE
Bump jupyterlab 4.5.7 → 4.5.9 (Dependabot #11)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # Pinned versions for reproducible builds
 
 # Core Jupyter environment
-jupyterlab==4.5.7
+jupyterlab==4.5.9
 nbclient==0.8.0
 ipython==8.25.0
 


### PR DESCRIPTION
Resolves Dependabot alert #11 (medium): stored XSS in the JupyterLab extension manager via unsanitized URI protocol in package metadata.

- Vulnerable: `<= 4.5.8`; first patched: `4.5.9`.
- `jupyterlab` is only used by the legacy notebook fallback workflow, not the production RDF pipeline.
- One-line pin bump in `requirements.txt`; no other manifest pins it.