### PR TITLE
fix(gene_mapper): normalize BridgeDb base URL so a missing slash can't silently drop all gene xrefs

### DIFF
--- a/src/aopwiki_rdf/mapping/gene_mapper.py
+++ b/src/aopwiki_rdf/mapping/gene_mapper.py
@@ -418,6 +418,11 @@ def _batch_xrefs_bridgedb(gene_list: list[str], bridgedb_url: str,
     dict
         Mapping of gene_id -> {db_name: [identifiers]}.
     """
+    # Endpoints are appended directly to the base (e.g. + 'xrefsBatch/H'), so it
+    # must end in '/'. A missing trailing slash yields '.../HumanxrefsBatch/H',
+    # which 404s for every gene and silently drops all external xrefs. Normalize
+    # here as ner_el_mapper already does for its own BridgeDb calls.
+    bridgedb_url = bridgedb_url.rstrip('/') + '/'
     results = {}
     total_chunks = (len(gene_list) + chunk_size - 1) // chunk_size
 

--- a/tests/unit/test_gene_mapper.py
+++ b/tests/unit/test_gene_mapper.py
@@ -9,10 +9,12 @@ Tests cover:
 import os
 import pytest
 import requests
+from unittest.mock import patch, MagicMock
 
 from aopwiki_rdf.mapping.gene_mapper import (
     build_gene_dicts,
     build_gene_xrefs,
+    _batch_xrefs_bridgedb,
     _map_genes_in_text,
 )
 
@@ -180,3 +182,34 @@ def test_build_gene_xrefs_live():
     assert "hgnc:1100" in result["geneiddict"]
     assert "hgnc:11998" in result["geneiddict"]
     assert len(result["geneiddict"]["hgnc:1100"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# Test: BridgeDb base URL is normalized (regression for the missing-slash bug)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("base", [
+    "https://webservice.bridgedb.org/Human",   # no trailing slash (the bug)
+    "https://webservice.bridgedb.org/Human/",  # already correct
+])
+def test_batch_xrefs_normalizes_base_url(base):
+    """A missing trailing slash must not corrupt the endpoint.
+
+    Without normalization, ``base + 'xrefsBatch/H'`` yields
+    ``.../HumanxrefsBatch/H``, which 404s for every gene and silently drops all
+    external cross-references. The batch endpoint must always be built against a
+    slash-terminated base.
+    """
+    captured = {}
+
+    def fake_post(url, *args, **kwargs):
+        captured["url"] = url
+        resp = MagicMock()
+        resp.text = ""            # no rows -> parser skips, no xrefs needed
+        resp.raise_for_status.return_value = None
+        return resp
+
+    with patch("aopwiki_rdf.mapping.gene_mapper.requests.post", side_effect=fake_post):
+        _batch_xrefs_bridgedb(["hgnc:1100"], base, timeout=5)
+
+    assert captured["url"] == "https://webservice.bridgedb.org/Human/xrefsBatch/H"


### PR DESCRIPTION
## Problem

`_batch_xrefs_bridgedb` appends BridgeDb endpoints directly to the base URL:

```python
batch_url = bridgedb_url + 'xrefsBatch/H'      # and: bridgedb_url + 'xrefs/H/' + symbol
```

If `bridgedb_url` lacks a trailing slash, this builds `https://webservice.bridgedb.org/HumanxrefsBatch/H`, which **404s for every gene**. The failure is silent: the Genes TTL is still written (with only HGNC self-identifiers), and validation passes — so a run looks successful while every external cross-reference (Ensembl / NCBIGene / UniProt) is missing.

This actually happened downstream: the `AOP-Wiki_multi-endpoint` `quarterly-update` workflow passed `--bridgedb-url https://webservice.bridgedb.org/Human` (no slash), and the 2026-07-01 Genes file collapsed from ~2.1 MB / ~19.7k xrefs to ~315 KB / ~1.5k before it was caught. `PipelineConfig.bridgedb_url` defaults to the slash-terminated form, so only an explicit override triggers it.

## Fix

Normalize the base once at the top of `_batch_xrefs_bridgedb`:

```python
bridgedb_url = bridgedb_url.rstrip('/') + '/'
```

This is exactly what `ner_el_mapper` already does for its own BridgeDb calls (`base = bridgedb_url.rstrip("/") + "/"`) — this change brings `gene_mapper` in line so a missing slash can never again silently drop all gene mappings.

## Test

Adds a network-free regression test (`test_batch_xrefs_normalizes_base_url`) that mocks `requests.post` and asserts both slash-less and slash-terminated bases resolve to `.../Human/xrefsBatch/H`. Full `tests/unit/test_gene_mapper.py`: 7 passed, 1 skipped (live).
