### PR TITLE
build: bump jupyterlab 4.5.9 -> 4.6.2 to clear five open advisories

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # Pinned versions for reproducible builds
 
 # Core Jupyter environment
-jupyterlab==4.5.9
+jupyterlab==4.6.2
 nbclient==0.8.0
 ipython==8.25.0
 


### PR DESCRIPTION
Dependabot reports the 4.5.x line as patched in `4.5.10`, but that version is not published on PyPI — the 4.5.x line stops at 4.5.9. Every one of the five open advisories also lists a 4.6.x branch patched in **4.6.2**, which is released, so 4.6.2 is the only available version that clears all of them.

| Severity | Advisory | Issue |
|---|---|---|
| high | GHSA-pppj-hq3g-57pj | XSS via crafted `overrides.json` |
| high | GHSA-gx64-gj6p-pc4c | XSS in image viewer opened in a new tab |
| medium | GHSA-h5v5-8746-g7mm | PluginManager lock-rule enforcement bypass |
| medium | GHSA-89vp-jrxv-24w8 | PyPI blocklist name-canonicalization bypass |
| low | GHSA-whvh-wf3x-g77j | allowlist check not awaited in `install()` |

`jupyterlab` is only used by the legacy notebook fallback workflow; the production Python pipeline does not import it. No data files are touched.