### PR TITLE
fix(qc): guard gene associations in both directions

### DIFF
--- a/.github/workflows/Turtle_File_Quality_Control.yml
+++ b/.github/workflows/Turtle_File_Quality_Control.yml
@@ -5,6 +5,18 @@ on:
     paths:
       - 'data/**'
   workflow_dispatch:
+    inputs:
+      expect_gene_change:
+        description: >-
+          Declare a gene-association change intentional so the delta guard
+          reports it instead of failing. Use "drop" for a precision fix that
+          removes false positives, "rise" for a deliberate recall improvement.
+          The direction is enforced: declaring "drop" and then seeing a rise
+          still fails.
+        required: false
+        default: none
+        type: choice
+        options: [none, drop, rise, any]
   workflow_run:
     workflows: [RDF Generation]
     types:
@@ -156,7 +168,16 @@ jobs:
             rm -rf delta-baseline
             exit 0
           fi
-          python scripts/qc_delta_guard.py --new-dir data/ --baseline-dir delta-baseline/ --coverage-baseline scripts/coverage-ratchet-baseline.json --drop-pct 0.05
+          # Manual runs may declare an intentional gene change; scheduled and
+          # workflow_run invocations never can, so they always get the strict
+          # two-sided guard.
+          EXPECT="${{ github.event.inputs.expect_gene_change || 'none' }}"
+          EXPECT_FLAG=""
+          if [ "$EXPECT" != "none" ]; then
+            EXPECT_FLAG="--expect-gene-change $EXPECT"
+            echo "::notice::Gene-association $EXPECT declared intentional for this run"
+          fi
+          python scripts/qc_delta_guard.py --new-dir data/ --baseline-dir delta-baseline/ --coverage-baseline scripts/coverage-ratchet-baseline.json --drop-pct 0.05 $EXPECT_FLAG
           rm -rf delta-baseline
 
       # Step 6: Commit and Push QC Status File to /data

--- a/scripts/qc_delta_guard.py
+++ b/scripts/qc_delta_guard.py
@@ -15,16 +15,32 @@ Counting
   ``-Genes.ttl``). Counted by exact predicate URI, NOT prefix parsing.
 * Total triples = ``len(Graph)`` for each file.
 
-Threshold policy (defaults; tunable via ``--drop-pct``)
--------------------------------------------------------
+Threshold policy (defaults; tunable via ``--drop-pct`` / ``--rise-pct``)
+------------------------------------------------------------------------
 * Fail if a new count drops below ``(1 - drop_pct) * baseline``.
 * Default ``drop_pct`` is 0.05, i.e. a strictly-greater-than 5% drop fails.
   Rationale: a normal weekly AOP-Wiki update moves counts well under 5%; a
-  larger drop indicates a silent loss (outage / parser regression). An
-  INCREASE always passes; a within-threshold change always passes.
+  larger drop indicates a silent loss (outage / parser regression).
+* Gene associations are ALSO guarded on the way up: fail if they exceed
+  ``(1 + rise_pct) * baseline``, default 25%. The guard was originally
+  one-sided, which meant a matcher regression that started admitting false
+  positives -- an alias colliding with a common word -- passed silently, while
+  a deliberate precision fix tripped the alarm. Both directions are now
+  data-quality signals. The rise bar sits well above the drop bar because
+  legitimate growth is asymmetric: AOP-Wiki adds Key Events far faster than it
+  removes them.
 * Total-triple drop is checked for BOTH ``AOPWikiRDF.ttl`` and
-  ``AOPWikiRDF-Genes.ttl``; gene-association drop is checked for
-  ``AOPWikiRDF-Genes.ttl``.
+  ``AOPWikiRDF-Genes.ttl``; gene-association checks apply to
+  ``AOPWikiRDF-Genes.ttl``. Total triples are NOT rise-checked -- they grow
+  normally as curators add content.
+* ``--expect-gene-change {drop,rise,any}`` declares gene movement in that
+  direction intentional: the delta is still measured and printed, but does not
+  fail the run. For precision work, where removing false positives is the goal
+  and blocking on the resulting drop would be backwards. Direction is enforced
+  -- declaring ``drop`` and then observing a rise still fails, since that is
+  exactly the mistake worth catching. An acknowledged drop also covers the
+  ``-Genes.ttl`` total-triple fall that necessarily follows from removing
+  associations; ``AOPWikiRDF.ttl`` stays blocking.
 * A MISSING baseline file OR MISSING new file is a HARD FAIL (cannot prove
   safety).
 
@@ -51,6 +67,16 @@ MAIN_FILE = "AOPWikiRDF.ttl"
 GENES_FILE = "AOPWikiRDF-Genes.ttl"
 
 DEFAULT_DROP_PCT = 0.05
+
+# Gene associations are also guarded on the way UP. A drop means silent loss (a
+# BERN2 outage); a large rise means the matcher started accepting things it
+# should not -- an alias collision reaching a common word, say -- and that is
+# just as much a data-quality failure, but the original one-sided guard passed
+# it silently. Set well above the drop threshold because legitimate upstream
+# growth is genuinely asymmetric: AOP-Wiki adds Key Events far faster than it
+# removes them. Only gene associations are rise-checked; total triples grow
+# normally as curators add content.
+DEFAULT_RISE_PCT = 0.25
 DEFAULT_NEW_DIR = "data"
 DEFAULT_BASELINE_DIR = "production-rdf-backup"
 DEFAULT_REPORT_PATH = "qc-delta-report.json"
@@ -205,7 +231,8 @@ def load_element_predicate_map(coverage_baseline_path):
     return data.get("element_predicates", {})
 
 
-def compare(new_path, baseline_path, drop_pct, check_genes):
+def compare(new_path, baseline_path, drop_pct, check_genes,
+            rise_pct=DEFAULT_RISE_PCT, expect_gene_change=None):
     """Compare one new TTL against its baseline.
 
     Parameters
@@ -214,6 +241,21 @@ def compare(new_path, baseline_path, drop_pct, check_genes):
         Path to the freshly generated TTL.
     baseline_path : str
         Path to the last-known-good baseline TTL.
+    rise_pct : float
+        Fractional rise threshold for gene associations. A rise strictly
+        greater than this fraction is a breach.
+    expect_gene_change : str or None
+        One of ``"drop"``, ``"rise"``, ``"any"``, or None. Declares that gene
+        movement in that direction is intentional: it is measured and printed
+        but does not breach. Direction matters -- declaring a precision fix
+        (``drop``) and then observing a RISE is precisely the mistake worth
+        failing on, so ``drop`` does not excuse a rise.
+
+        Because gene associations are the bulk of ``-Genes.ttl``, an
+        acknowledged gene change also covers that file's total-triple drop;
+        removing associations necessarily removes triples. ``AOPWikiRDF.ttl``
+        stays blocking regardless -- an intentional gene change is no licence
+        to lose unrelated source triples.
     drop_pct : float
         Fractional drop threshold. A drop strictly greater than this fraction
         is a breach.
@@ -271,11 +313,18 @@ def compare(new_path, baseline_path, drop_pct, check_genes):
 
     # Total-triple drop check (an increase or within-threshold change passes).
     if baseline_total > 0 and new_total < (1 - drop_pct) * baseline_total:
-        result["breached"] = True
-        result["reasons"].append(
+        total_reason = (
             f"total triples dropped {result['total_delta_pct'] * 100:.2f}% "
             f"({baseline_total} -> {new_total}), exceeds {drop_pct * 100:.1f}% threshold"
         )
+        # A declared gene DROP explains the -Genes.ttl total falling with it,
+        # since those associations are most of that file. It explains nothing
+        # about AOPWikiRDF.ttl.
+        if check_genes and expect_gene_change in ("drop", "any"):
+            result.setdefault("acknowledged", []).append(total_reason)
+        else:
+            result["breached"] = True
+            result["reasons"].append(total_reason)
 
     if check_genes:
         baseline_genes = count_gene_associations(baseline_graph)
@@ -284,13 +333,36 @@ def compare(new_path, baseline_path, drop_pct, check_genes):
         result["new_genes"] = new_genes
         result["gene_delta_pct"] = _delta_pct(baseline_genes, new_genes)
 
+        result["gene_change_expected"] = expect_gene_change
+
+        gene_reason = None
         if baseline_genes > 0 and new_genes < (1 - drop_pct) * baseline_genes:
-            result["breached"] = True
-            result["reasons"].append(
+            gene_reason = (
                 f"gene associations (edam:data_1025) dropped "
                 f"{result['gene_delta_pct'] * 100:.2f}% "
                 f"({baseline_genes} -> {new_genes}), exceeds {drop_pct * 100:.1f}% threshold"
             )
+        elif baseline_genes > 0 and new_genes > (1 + rise_pct) * baseline_genes:
+            gene_reason = (
+                f"gene associations (edam:data_1025) rose "
+                f"{result['gene_delta_pct'] * 100:.2f}% "
+                f"({baseline_genes} -> {new_genes}), exceeds {rise_pct * 100:.1f}% "
+                f"rise threshold -- check for a matcher regression admitting "
+                f"false positives"
+            )
+
+        observed_direction = (
+            "drop" if result["gene_delta_pct"] is not None
+            and result["gene_delta_pct"] < 0 else "rise"
+        )
+        if gene_reason:
+            if expect_gene_change in (observed_direction, "any"):
+                # Recorded for the report and surfaced by print_report, but not
+                # a breach: the operator declared this change intentional.
+                result.setdefault("acknowledged", []).append(gene_reason)
+            else:
+                result["breached"] = True
+                result["reasons"].append(gene_reason)
 
     return result
 
@@ -322,6 +394,10 @@ def print_report(report, warn_only=False):
         if entry["reasons"]:
             for reason in entry["reasons"]:
                 print(f"  BREACH: {reason}")
+        # Movement the operator declared intentional. Printed so a reader can
+        # still see WHAT changed -- an acknowledged delta is not a hidden one.
+        for reason in entry.get("acknowledged", []):
+            print(f"  ACKNOWLEDGED (--expect-gene-change): {reason}")
     if "per_element" in report:
         print("\nPer-element predicate counts (relative floor):")
         for element, entry in report["per_element"].items():
@@ -342,7 +418,8 @@ def print_report(report, warn_only=False):
 
 def run(new_dir, baseline_dir, drop_pct=DEFAULT_DROP_PCT,
         report_path=DEFAULT_REPORT_PATH, per_element=False,
-        element_predicates=None):
+        element_predicates=None, rise_pct=DEFAULT_RISE_PCT,
+        expect_gene_change=None):
     """Compare both checked files and write the JSON report.
 
     Parameters
@@ -380,6 +457,8 @@ def run(new_dir, baseline_dir, drop_pct=DEFAULT_DROP_PCT,
             os.path.join(baseline_dir, filename),
             drop_pct=drop_pct,
             check_genes=check_genes,
+            rise_pct=rise_pct,
+            expect_gene_change=expect_gene_change,
         )
         file_reports.append(entry)
 
@@ -387,8 +466,15 @@ def run(new_dir, baseline_dir, drop_pct=DEFAULT_DROP_PCT,
     for entry in file_reports:
         aggregated_reasons.extend(entry["reasons"])
 
+    aggregated_acknowledged = []
+    for entry in file_reports:
+        aggregated_acknowledged.extend(entry.get("acknowledged", []))
+
     report = {
         "drop_pct": drop_pct,
+        "rise_pct": rise_pct,
+        "gene_change_expected": expect_gene_change,
+        "acknowledged": aggregated_acknowledged,
         "new_dir": new_dir,
         "baseline_dir": baseline_dir,
         "files": file_reports,
@@ -434,6 +520,21 @@ def main(argv=None):
     parser.add_argument("--drop-pct", type=float, default=DEFAULT_DROP_PCT,
                         help="Fractional drop threshold; a drop greater than "
                              "this fails (default: 0.05 = 5%%)")
+    parser.add_argument("--rise-pct", type=float, default=DEFAULT_RISE_PCT,
+                        help="Fractional RISE threshold for gene associations; "
+                             "a rise greater than this fails, catching a "
+                             "matcher regression that admits false positives "
+                             "(default: 0.25 = 25%%)")
+    parser.add_argument("--expect-gene-change", choices=("drop", "rise", "any"),
+                        default=None,
+                        help="Declare gene-association movement in this "
+                             "DIRECTION intentional (e.g. 'drop' for a "
+                             "precision fix removing false positives). The "
+                             "delta is measured and printed but does not fail. "
+                             "Direction matters: declaring 'drop' and then "
+                             "seeing a rise still fails. Also covers the "
+                             "-Genes.ttl total-triple drop that necessarily "
+                             "follows; AOPWikiRDF.ttl stays blocking.")
     parser.add_argument("--report-path", default=DEFAULT_REPORT_PATH,
                         help="Path to write qc-delta-report.json "
                              "(default: qc-delta-report.json)")
@@ -458,6 +559,8 @@ def main(argv=None):
         report_path=args.report_path,
         per_element=per_element,
         element_predicates=element_predicates,
+        rise_pct=args.rise_pct,
+        expect_gene_change=args.expect_gene_change,
     )
     print_report(report, warn_only=args.warn_only)
 

--- a/tests/unit/test_qc_delta_guard.py
+++ b/tests/unit/test_qc_delta_guard.py
@@ -127,9 +127,19 @@ def test_gene_drop_trips_guard(tmp_path):
 
 
 def test_increase_passes(tmp_path):
-    """(c) more triples and more genes than baseline -> increase passes."""
+    """(c) more triples and more genes than baseline -> increase passes.
+
+    Gene associations are now guarded in BOTH directions, so "an increase always
+    passes" is no longer true without qualification: a rise beyond
+    ``DEFAULT_RISE_PCT`` (25%) is a breach, because a matcher that suddenly
+    admits far more matches is usually admitting false positives. This case uses
+    a +15% rise -- ordinary upstream growth, comfortably inside the band. The
+    breach side is covered in tests/unit/test_qc_delta_two_sided.py.
+
+    Total triples are deliberately NOT rise-checked, so new_main may grow freely.
+    """
     new_dir, baseline_dir = _write_pair(
-        tmp_path, baseline_genes=100, new_genes=130,
+        tmp_path, baseline_genes=100, new_genes=115,
         baseline_main=20, new_main=40,
     )
     report = guard.run(new_dir, baseline_dir, drop_pct=0.05,

--- a/tests/unit/test_qc_delta_two_sided.py
+++ b/tests/unit/test_qc_delta_two_sided.py
@@ -1,0 +1,161 @@
+"""Tests for the two-sided gene-association delta guard.
+
+The guard was originally one-directional: it failed on a drop and said nothing
+about a rise. That meant a matcher regression admitting false positives shipped
+silently, while a deliberate precision fix -- whose entire purpose is to remove
+associations -- tripped the alarm and looked identical to a data-loss incident.
+"""
+
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'scripts'))
+
+from qc_delta_guard import compare  # noqa: E402
+
+PREFIXES = (
+    '@prefix edam: <http://edamontology.org/> .\n'
+    '@prefix ex: <http://e.org/> .\n'
+)
+
+GENES_FILE = 'AOPWikiRDF-Genes.ttl'
+MAIN_FILE = 'AOPWikiRDF.ttl'
+
+
+def write_ttl(path, gene_assocs, other=50):
+    with open(path, 'w') as f:
+        f.write(PREFIXES)
+        for i in range(gene_assocs):
+            f.write(f'ex:e{i} edam:data_1025 ex:g{i} .\n')
+        for i in range(other):
+            f.write(f'ex:e{i} ex:p ex:o{i} .\n')
+
+
+@pytest.fixture
+def pair(tmp_path):
+    """Return a (baseline_path, make_new) pair for the Genes file."""
+    base = tmp_path / 'base'
+    new = tmp_path / 'new'
+    base.mkdir()
+    new.mkdir()
+    write_ttl(base / GENES_FILE, 100)
+
+    def make_new(gene_assocs, other=50):
+        write_ttl(new / GENES_FILE, gene_assocs, other)
+        return str(new / GENES_FILE)
+
+    return str(base / GENES_FILE), make_new
+
+
+def run(baseline, new_path, **kw):
+    kw.setdefault('drop_pct', 0.05)
+    kw.setdefault('check_genes', True)
+    return compare(new_path, baseline, **kw)
+
+
+# --- Ordinary weekly movement ---------------------------------------------
+
+@pytest.mark.parametrize('count', [98, 100, 104])
+def test_small_movement_passes(pair, count):
+    baseline, make_new = pair
+    assert run(baseline, make_new(count))['breached'] is False
+
+
+# --- Drop: the BERN2-outage class -----------------------------------------
+
+def test_large_drop_breaches(pair):
+    baseline, make_new = pair
+    result = run(baseline, make_new(60))
+
+    assert result['breached'] is True
+    assert any('dropped' in r for r in result['reasons'])
+
+
+# --- Rise: the regression class the old guard missed -----------------------
+
+def test_large_rise_breaches(pair):
+    """A matcher admitting false positives is a quality failure too."""
+    baseline, make_new = pair
+    result = run(baseline, make_new(160))
+
+    assert result['breached'] is True
+    assert any('rose' in r for r in result['reasons'])
+
+
+def test_rise_within_threshold_passes(pair):
+    """Legitimate growth is asymmetric; the rise bar sits well above the drop bar."""
+    baseline, make_new = pair
+    assert run(baseline, make_new(120))['breached'] is False
+
+
+# --- Declaring the change intentional --------------------------------------
+
+def test_expected_drop_is_acknowledged_not_breached(pair):
+    baseline, make_new = pair
+    result = run(baseline, make_new(60), expect_gene_change='drop')
+
+    assert result['breached'] is False
+    assert any('dropped' in r for r in result['acknowledged'])
+
+
+def test_expected_drop_also_covers_the_genes_file_total(pair):
+    """Removing associations necessarily removes triples from -Genes.ttl.
+
+    Without this, a declared precision fix still fails on the total-triple
+    check it inevitably causes.
+    """
+    baseline, make_new = pair
+    result = run(baseline, make_new(60), expect_gene_change='drop')
+
+    assert result['breached'] is False
+    assert any('total triples' in r for r in result['acknowledged'])
+
+
+def test_declaring_a_drop_does_not_excuse_a_rise(pair):
+    """The direction is the point -- this is the mistake worth catching."""
+    baseline, make_new = pair
+    result = run(baseline, make_new(160), expect_gene_change='drop')
+
+    assert result['breached'] is True
+    assert any('rose' in r for r in result['reasons'])
+
+
+def test_expected_rise_is_acknowledged(pair):
+    """For a deliberate recall improvement, e.g. enabling a new NER source."""
+    baseline, make_new = pair
+    result = run(baseline, make_new(160), expect_gene_change='rise')
+
+    assert result['breached'] is False
+
+
+def test_any_accepts_either_direction(pair):
+    baseline, make_new = pair
+    assert run(baseline, make_new(60), expect_gene_change='any')['breached'] is False
+    assert run(baseline, make_new(160), expect_gene_change='any')['breached'] is False
+
+
+# --- The real incident this was built from ---------------------------------
+
+def test_the_2026_08_01_bern2_shortfall_is_still_only_a_pass(pair, tmp_path):
+    """The 2026-08-01 run lost 3.1% of associations and passed silently.
+
+    That is genuinely within the 5% band, so the guard should still pass -- the
+    fix for that case is threshold tuning, not the two-sided change. Pinned so a
+    later threshold edit is a deliberate decision rather than an accident.
+    """
+    baseline, make_new = pair
+    result = run(baseline, make_new(97))
+
+    assert result['breached'] is False
+    assert result['gene_delta_pct'] == pytest.approx(-0.03, abs=0.005)
+
+
+def test_report_records_the_direction_declared(pair):
+    baseline, make_new = pair
+    result = run(baseline, make_new(60), expect_gene_change='drop')
+
+    assert result['gene_change_expected'] == 'drop'
+    assert json.dumps(result)  # report must stay JSON-serialisable


### PR DESCRIPTION
The delta guard only failed on a **drop**, which left it blind in one direction and actively wrong in the other.

**Blind:** a matcher regression that starts admitting false positives inflates gene associations — just as much a data-quality failure as losing them — and passed silently.

**Wrong:** a deliberate precision fix removes associations on purpose, so the guard fired on exactly the intended change and made it indistinguishable from a data-loss incident. This currently blocks the gene-mapper precision work.

## Changes

- Gene associations are now checked on the way **up** too, failing beyond `--rise-pct` (default 25%). The bar sits well above the 5% drop bar because legitimate growth is asymmetric — AOP-Wiki adds Key Events far faster than it removes them. Total triples are **not** rise-checked; they grow normally as curators add content.
- `--expect-gene-change {drop,rise,any}` declares movement in that direction intentional. The delta is still measured and printed as `ACKNOWLEDGED`, but does not fail. **Direction is enforced:** declaring `drop` and then observing a rise still fails, which is precisely the mistake worth catching.
- A declared drop also covers the `-Genes.ttl` total-triple fall that necessarily follows from removing associations — otherwise a declared precision fix still fails on the total check it inevitably causes. `AOPWikiRDF.ttl` stays blocking.
- Exposed as a `workflow_dispatch` choice input. Scheduled and `workflow_run` invocations cannot set it, so automated runs always get the strict guard.

## Verified

13 new tests plus the full unit suite (285 passed). Six end-to-end scenarios checked against the CLI: normal movement passes; a 40% drop fails; a 60% rise fails; a declared drop is acknowledged; a rise while declaring a drop still fails; a declared rise is acknowledged.

## Note for the record

The 2026-08-01 run lost 3.1% of gene associations to a BERN2 shortfall and passed silently. That is genuinely inside the 5% band, so this change does **not** catch it — that would be threshold tuning. It is pinned as a test so any future edit to that threshold is a deliberate decision.

No data files are touched.