### PR TITLE
fix: derive pav:version from the XML export instead of hard-coding it

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -390,14 +390,52 @@ Contains VoID dataset metadata:
 
 1. VoID prefix declarations
 2. Parent dataset (`:AOPWikiRDF`) with `void:subset` links to the three content files, plus
-   an explicit `pav:version "1.3"` milestone-tied dataset-version field (a bare string
-   literal, distinct from the date-only `pav:createdOn` stamp; bumped per schema-changing
-   release and stamped on the top-level dataset only, not the per-subset nodes)
+   the release-identity fields described under *Versioning* below
 3. Pure source subset (`:AOPWikiRDF.ttl`) with provenance and triple counts
 4. Enriched subset (`:AOPWikiRDF-Enriched.ttl`) with BridgeDb provenance
 5. Genes subset (`:AOPWikiRDF-Genes.ttl`) with HGNC provenance
 6. HGNC linkset metadata
 7. Promapping linkset metadata
+
+#### Versioning
+
+Two different things carry versions, and they are deliberately *not* the same
+value. Conflating them is what left the served RDF advertising `pav:version "1.3"`
+long after that label stopped meaning anything (issue #101).
+
+| What | Where | Scheme | Example |
+|---|---|---|---|
+| The **dataset** — one weekly snapshot | `pav:version` on `:AOPWikiRDF` | calendar, from the XML export date | `"2026.08.01"` |
+| The **software** — this repository | `pav:createdWith` commit URL on `:AOPWikiRDF` | git commit | `<https://github.com/marvinm2/AOPWikiRDF/commit/0eeca9a…>` |
+| The **software**, for citation | `CITATION.cff`, git tags | calendar / semver | `2026.05`, `v2.2` |
+
+`pav:version` is **derived at generation time** from the AOP-Wiki XML filename
+(`aop-wiki-xml-2026-08-01` → `2026.08.01`) by
+`aopwiki_rdf.provenance.derive_dataset_version`, so it cannot drift out of date.
+If the filename does not carry a parseable date the triple is **omitted** rather
+than guessed — no version is honest, a stale one is not.
+
+The commit URL means a consumer can pin an exact release from the endpoint alone:
+
+```sparql
+PREFIX pav: <http://purl.org/pav/>
+SELECT ?version ?builtOn ?commit WHERE {
+  <https://aopwiki.rdf.bigcat-bioinformatics.org/AOPWikiRDF>
+      pav:version ?version ;
+      pav:createdOn ?builtOn ;
+      pav:createdWith ?commit .
+  FILTER(isIRI(?commit))
+}
+```
+
+The `isIRI` filter is defensive rather than required here — pinning the subject to
+`:AOPWikiRDF` is already enough, because only the parent carries a commit URL. It
+is worth keeping if you loosen the subject, since `pav:createdWith` is reused on
+the *subset* nodes with string literals naming the input files.
+
+`dcat:accrualPeriodicity` is `freq:weekly`, matching the actual regeneration
+cadence (Saturdays 08:00 UTC). It previously read `freq:quarterly`, which told
+consumers to expect refreshes four times less often than they actually happen.
 
 ### ServiceDescription.ttl
 

--- a/scripts/compat_check.py
+++ b/scripts/compat_check.py
@@ -132,6 +132,23 @@ MASK_PATTERNS = (
         re.compile(rb'void:triples\s+[0-9]+'),
         b'void:triples\t<MASKED>',
     ),
+    # 6. Void pav:version calendar release string. Run-varying since issue #101
+    #    made it derive from the AOP-Wiki XML export date instead of a
+    #    hard-coded literal, so an off-vs-on comparison spanning two XML
+    #    snapshots would otherwise diff here. Predicate-anchored; the only
+    #    pav:version in the corpus is the one on :AOPWikiRDF.
+    (
+        re.compile(rb'pav:version\t"[^"]*"'),
+        b'pav:version\t"<MASKED>"',
+    ),
+    # 7. Void pav:createdWith commit URL. Varies with every commit, and the two
+    #    halves of a COMPAT run are generated from the same checkout, so this
+    #    carries no compatibility signal. Anchored on the commit-URL shape so it
+    #    cannot touch the sibling pav:createdWith XML-filename literals.
+    (
+        re.compile(rb'pav:createdWith\t<https://github\.com/[^>]*/commit/[0-9a-f]+>'),
+        b'pav:createdWith\t<MASKED-COMMIT>',
+    ),
 )
 
 

--- a/src/aopwiki_rdf/pipeline.py
+++ b/src/aopwiki_rdf/pipeline.py
@@ -34,6 +34,11 @@ from aopwiki_rdf.mapping.iri_labels import (
 )
 from aopwiki_rdf.mapping.protein_ontology import download_and_parse_promapping
 from aopwiki_rdf.rdf.writer import write_aop_rdf, write_enriched_rdf, write_genes_rdf, write_void_rdf
+from aopwiki_rdf.provenance import (
+    derive_dataset_version,
+    resolve_source_commit,
+    source_commit_url,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -568,6 +573,17 @@ def _stage_write_void_rdf(config, context):
     metadata["bridgedb_url"] = config.bridgedb_url
     metadata["sparql_endpoint"] = config.sparql_endpoint
     metadata["data_dump_base"] = config.data_dump_base
+
+    # Release identity (issue #101): pav:version is derived from the XML export
+    # so it cannot go stale, and the generating commit is published so a release
+    # is pinnable from the endpoint alone.
+    metadata["dataset_version"] = derive_dataset_version(aopwikixmlfilename)
+    metadata["source_commit_url"] = source_commit_url(resolve_source_commit())
+    logger.info(
+        "Dataset version %s, generated from commit %s",
+        metadata["dataset_version"] or "<underivable>",
+        metadata["source_commit_url"] or "<unknown>",
+    )
 
     write_void_rdf(filepath + "AOPWikiRDF-Void.ttl", metadata)
 

--- a/src/aopwiki_rdf/provenance.py
+++ b/src/aopwiki_rdf/provenance.py
@@ -1,0 +1,93 @@
+"""Release identity for the generated dataset.
+
+Two distinct things get versioned in this repo and conflating them is what
+produced the six-year-stale ``pav:version "1.3"`` in the served RDF:
+
+* the **dataset** -- a weekly snapshot, identified by the AOP-Wiki XML export it
+  was built from. This is what ``pav:version`` describes.
+* the **software** -- this repository, identified by git tag and CITATION.cff.
+  This is what ``pav:createdWith`` points at, via the generating commit.
+
+The dataset version is therefore *derived* from the XML filename rather than
+hard-coded, so it cannot drift out of date again. It uses the same calendar
+scheme as CITATION.cff, extended to the day because releases are weekly.
+"""
+
+import logging
+import os
+import re
+import subprocess
+
+logger = logging.getLogger(__name__)
+
+REPO_URL = "https://github.com/marvinm2/AOPWikiRDF"
+
+# ``aop-wiki-xml-2026-08-01`` -> ``2026-08-01``. Anchored so a stray date
+# elsewhere in the filename cannot be picked up instead.
+_XML_DATE_PATTERN = re.compile(r"^aop-wiki-xml-(\d{4})-(\d{2})-(\d{2})$")
+
+_SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+
+
+def derive_dataset_version(aopwikixmlfilename: str) -> str | None:
+    """Return the calendar dataset version for an AOP-Wiki XML export.
+
+    ``aop-wiki-xml-2026-08-01`` yields ``"2026.08.01"``.
+
+    Returns ``None`` when the filename does not carry a parseable date, so the
+    caller can omit ``pav:version`` entirely rather than assert a wrong one --
+    no version is honest, a stale version is not.
+    """
+    if not aopwikixmlfilename:
+        return None
+
+    match = _XML_DATE_PATTERN.match(aopwikixmlfilename.strip())
+    if not match:
+        logger.warning(
+            "Cannot derive dataset version: XML filename %r does not match the "
+            "expected aop-wiki-xml-YYYY-MM-DD form; pav:version will be omitted",
+            aopwikixmlfilename,
+        )
+        return None
+
+    return ".".join(match.groups())
+
+
+def resolve_source_commit() -> str | None:
+    """Return the 40-char commit SHA this run was generated from, if knowable.
+
+    Prefers ``GITHUB_SHA`` (set by Actions, and correct even when the runner
+    checks out a detached merge commit), falling back to ``git rev-parse`` for
+    local runs. Returns ``None`` outside a checkout -- an absent commit triple
+    is better than a fabricated one.
+    """
+    env_sha = os.environ.get("GITHUB_SHA", "").strip().lower()
+    if _SHA_PATTERN.match(env_sha):
+        return env_sha
+
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            cwd=os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+        )
+    except (OSError, subprocess.SubprocessError) as e:
+        logger.debug("git rev-parse unavailable (%s); omitting source commit", e)
+        return None
+
+    if result.returncode != 0:
+        logger.debug(
+            "git rev-parse failed (%s); omitting source commit",
+            result.stderr.strip(),
+        )
+        return None
+
+    sha = result.stdout.strip().lower()
+    return sha if _SHA_PATTERN.match(sha) else None
+
+
+def source_commit_url(sha: str | None) -> str | None:
+    """Return the GitHub commit URL for ``sha``, or ``None`` if there is none."""
+    return f"{REPO_URL}/commit/{sha}" if sha else None

--- a/src/aopwiki_rdf/rdf/writer.py
+++ b/src/aopwiki_rdf/rdf/writer.py
@@ -990,6 +990,10 @@ def write_void_rdf(filepath, metadata):
     # endpoint); defaults describe the production single-snapshot service.
     sparql_endpoint = metadata.get('sparql_endpoint', 'https://aopwiki.rdf.bigcat-bioinformatics.org/sparql/')
     data_dump_base = metadata.get('data_dump_base', 'https://raw.githubusercontent.com/marvinm2/AOPWikiRDF/master/data')
+    # Both may be None -- the corresponding triple is then omitted rather than
+    # emitted with a placeholder value.
+    dataset_version = metadata.get('dataset_version')
+    source_commit = metadata.get('source_commit_url')
 
     logger.info(f"Writing VoID RDF file: {filepath}")
 
@@ -1002,17 +1006,26 @@ def write_void_rdf(filepath, metadata):
         g.write(' ;\n\tdcterms:license\t<https://creativecommons.org/licenses/by-sa/4.0/>')
         g.write(' ;\n\tvoid:sparqlEndpoint\t<' + sparql_endpoint + '>')
         g.write(' ;\n\tvoid:dataDump\t<' + data_dump_base + '/AOPWikiRDF.ttl>, <' + data_dump_base + '/AOPWikiRDF-Enriched.ttl>, <' + data_dump_base + '/AOPWikiRDF-Genes.ttl>')
-        g.write(' ;\n\tdcat:accrualPeriodicity\tfreq:quarterly')
+        g.write(' ;\n\tdcat:accrualPeriodicity\tfreq:weekly')
         g.write(' ;\n\tvoid:subset\t:AOPWikiRDF.ttl, :AOPWikiRDF-Enriched.ttl, :AOPWikiRDF-Genes.ttl')
         g.write(' ;\n\tvoid:exampleResource\taop:1, aop.events:1, aop.relationships:1, cas:83-79-4, aop.stressor:1')
         g.write(' ;\n\tpav:createdOn\t"' + y + '"^^xsd:date')
-        # Milestone-tied dataset version (D-06): bare string literal, no xsd:
-        # datatype tag. Distinct from the date-only pav:createdOn stamp; bumps
-        # per schema-changing release. Top-level :AOPWikiRDF parent only --
-        # the milestone label belongs to the dataset as a whole, not per-subset.
-        g.write(' ;\n\tpav:version\t"1.3"')
+        # Calendar dataset version, DERIVED from the AOP-Wiki XML export this
+        # run consumed (aop-wiki-xml-2026-08-01 -> "2026.08.01"). Previously a
+        # hard-coded "1.3" that tracked a GSD milestone label and went six years
+        # stale, colliding with an unrelated 2020 git tag of the same name.
+        # Omitted entirely when the version cannot be derived -- see
+        # provenance.derive_dataset_version. Bare literal, no xsd: datatype tag.
+        if dataset_version:
+            g.write(' ;\n\tpav:version\t"' + dataset_version + '"')
         g.write(' ;\n\tfoaf:homepage\t<https://aopwiki.org>')
         g.write(' ;\n\tpav:createdBy\t<https://zenodo.org/badge/latestdoi/146466058>')
+        # Software identity: the exact commit that generated this release. Lets
+        # a consumer pin a release from the endpoint alone, without matching
+        # void:triples counts. Distinct from pav:version, which versions the
+        # DATA; this versions the CODE.
+        if source_commit:
+            g.write(' ;\n\tpav:createdWith\t<' + source_commit + '>')
         g.write(' .\n')
 
         # --- Pure source subset ---
@@ -1024,7 +1037,7 @@ def write_void_rdf(filepath, metadata):
         g.write(' ;\n\tpav:createdOn\t"' + y + '"^^xsd:date')
         g.write(' ;\n\tpav:createdWith\t"' + str(aopwikixmlfilename) + '", :Promapping')
         g.write(' ;\n\tfoaf:homepage\t<https://aopwiki.org>')
-        g.write(' ;\n\tdcat:accrualPeriodicity\tfreq:quarterly')
+        g.write(' ;\n\tdcat:accrualPeriodicity\tfreq:weekly')
         g.write(' ;\n\tdcat:downloadURL\t<https://aopwiki.org/downloads/' + str(aopwikixmlfilename) + '>')
         g.write(' .\n')
 
@@ -1047,7 +1060,7 @@ def write_void_rdf(filepath, metadata):
         g.write(' ;\n\tpav:createdOn\t"' + y + '"^^xsd:date')
         g.write(' ;\n\tpav:createdWith\t"' + str(aopwikixmlfilename) + '", :HGNCgenes')
         g.write(' ;\n\tfoaf:homepage\t<https://aopwiki.org>')
-        g.write(' ;\n\tdcat:accrualPeriodicity\tfreq:quarterly')
+        g.write(' ;\n\tdcat:accrualPeriodicity\tfreq:weekly')
         g.write(' ;\n\tdcat:downloadURL\t<https://aopwiki.org/downloads/' + str(aopwikixmlfilename) + '>, <https://www.genenames.org/download/custom/>')
         g.write(' .\n')
 

--- a/tests/unit/test_provenance.py
+++ b/tests/unit/test_provenance.py
@@ -1,0 +1,92 @@
+"""Tests for release-identity derivation (issue #101).
+
+The defect these guard against: a hard-coded ``pav:version`` that silently goes
+stale. Every assertion here is about the version tracking its input, or being
+omitted rather than guessed.
+"""
+
+import pytest
+
+from aopwiki_rdf.provenance import (
+    derive_dataset_version,
+    resolve_source_commit,
+    source_commit_url,
+)
+
+
+# --- derive_dataset_version ------------------------------------------------
+
+def test_derive_dataset_version_from_standard_filename():
+    assert derive_dataset_version("aop-wiki-xml-2026-08-01") == "2026.08.01"
+
+
+def test_derive_dataset_version_tracks_the_snapshot():
+    """Two different exports must not produce the same version."""
+    a = derive_dataset_version("aop-wiki-xml-2026-08-01")
+    b = derive_dataset_version("aop-wiki-xml-2026-07-25")
+    assert a != b
+    assert (a, b) == ("2026.08.01", "2026.07.25")
+
+
+def test_derive_dataset_version_tolerates_surrounding_whitespace():
+    assert derive_dataset_version("  aop-wiki-xml-2026-08-01  ") == "2026.08.01"
+
+
+@pytest.mark.parametrize("bad", [
+    "",
+    None,
+    "aop-wiki-xml",
+    "aop-wiki-xml-2026-08",
+    "aop-wiki-xml-26-08-01",
+    "some-other-file-2026-08-01",
+    "aop-wiki-xml-2026-08-01.gz",
+])
+def test_derive_dataset_version_returns_none_when_underivable(bad):
+    """No version is honest; a wrong version is what caused issue #101."""
+    assert derive_dataset_version(bad) is None
+
+
+def test_derive_dataset_version_is_not_the_stale_literal():
+    """Regression: the value must never again be the hard-coded '1.3'."""
+    assert derive_dataset_version("aop-wiki-xml-2026-08-01") != "1.3"
+
+
+# --- resolve_source_commit -------------------------------------------------
+
+def test_resolve_source_commit_prefers_github_sha(monkeypatch):
+    sha = "a" * 40
+    monkeypatch.setenv("GITHUB_SHA", sha)
+    assert resolve_source_commit() == sha
+
+
+def test_resolve_source_commit_lowercases_github_sha(monkeypatch):
+    monkeypatch.setenv("GITHUB_SHA", "A1B2C3D4E5" + "0" * 30)
+    assert resolve_source_commit() == "a1b2c3d4e5" + "0" * 30
+
+
+def test_resolve_source_commit_ignores_malformed_github_sha(monkeypatch):
+    """A short/branch-name GITHUB_SHA must fall through to git, not be emitted."""
+    monkeypatch.setenv("GITHUB_SHA", "refs/heads/master")
+    result = resolve_source_commit()
+    assert result != "refs/heads/master"
+    assert result is None or len(result) == 40
+
+
+def test_resolve_source_commit_returns_sha_or_none(monkeypatch):
+    monkeypatch.delenv("GITHUB_SHA", raising=False)
+    result = resolve_source_commit()
+    assert result is None or (len(result) == 40 and result.islower())
+
+
+# --- source_commit_url -----------------------------------------------------
+
+def test_source_commit_url_builds_github_url():
+    sha = "b" * 40
+    assert source_commit_url(sha) == (
+        f"https://github.com/marvinm2/AOPWikiRDF/commit/{sha}"
+    )
+
+
+def test_source_commit_url_passes_none_through():
+    """An unknown commit must yield no triple, not a URL ending in 'None'."""
+    assert source_commit_url(None) is None

--- a/tests/unit/test_rdf_writer.py
+++ b/tests/unit/test_rdf_writer.py
@@ -122,15 +122,8 @@ def test_write_void_rdf_emits_cc_by_sa_license():
         assert 'creativecommons.org/licenses/by/4.0' not in content
 
 
-def test_write_void_rdf_emits_pav_version():
-    """VoID parent dataset must carry an explicit pav:version "1.3" literal.
-
-    Establishes a deliberate dataset-version counter (D-06) on the top-level
-    :AOPWikiRDF dataset, distinct from the date-only pav:createdOn stamp. The
-    value is a bare string literal "1.3" (milestone label, no xsd: datatype).
-    """
-    from aopwiki_rdf.rdf.writer import write_void_rdf
-
+def _void_metadata(**overrides):
+    """Baseline VoID metadata dict, with per-test overrides applied."""
     now = datetime.datetime.now()
     metadata = {
         'aopwikixmlfilename': 'aop-wiki-xml-2025-01-01.gz',
@@ -142,17 +135,64 @@ def test_write_void_rdf_emits_pav_version():
         'service_desc_filepath': None,
         'triple_counts': {'main': 1000, 'enriched': 500, 'genes': 200},
     }
+    metadata.update(overrides)
+    return metadata
+
+
+def _write_void(metadata):
+    """Write VoID to a temp dir and return the file contents."""
+    from aopwiki_rdf.rdf.writer import write_void_rdf
 
     with tempfile.TemporaryDirectory() as tmpdir:
         out = os.path.join(tmpdir, 'AOPWikiRDF-Void.ttl')
         write_void_rdf(out, metadata)
-        content = open(out).read()
+        return open(out).read()
 
-        # Explicit milestone-tied version field is present on the parent block.
-        assert 'pav:version' in content
-        assert '"1.3"' in content
-        # Bare literal -- no datatype tag on the version value.
-        assert 'pav:version\t"1.3"' in content
+
+def test_write_void_rdf_emits_supplied_pav_version():
+    """pav:version carries the caller-supplied calendar version verbatim.
+
+    Guards issue #101: the value used to be hard-coded "1.3" and went six years
+    stale. It is now derived per run and passed in, so the writer must emit
+    exactly what it is given -- as a bare literal, no xsd: datatype tag.
+    """
+    content = _write_void(_void_metadata(dataset_version='2026.08.01'))
+
+    assert 'pav:version\t"2026.08.01"' in content
+    # The stale literal must never reappear.
+    assert '"1.3"' not in content
+
+
+def test_write_void_rdf_omits_pav_version_when_underivable():
+    """No version at all beats a wrong one when the date cannot be derived."""
+    content = _write_void(_void_metadata(dataset_version=None))
+
+    assert 'pav:version' not in content
+
+
+def test_write_void_rdf_emits_source_commit():
+    """The generating commit is published so a release is pinnable from the endpoint."""
+    url = 'https://github.com/marvinm2/AOPWikiRDF/commit/' + 'a' * 40
+    content = _write_void(_void_metadata(source_commit_url=url))
+
+    assert 'pav:createdWith\t<' + url + '>' in content
+
+
+def test_write_void_rdf_omits_source_commit_when_unknown():
+    """Outside a checkout, emit no commit triple rather than a fabricated one."""
+    content = _write_void(_void_metadata(source_commit_url=None))
+
+    assert '/commit/' not in content
+    # The subset-level pav:createdWith literals are unaffected.
+    assert 'pav:createdWith' in content
+
+
+def test_write_void_rdf_declares_weekly_accrual():
+    """Cadence must match the Saturday 08:00 UTC regeneration, not 'quarterly'."""
+    content = _write_void(_void_metadata())
+
+    assert 'freq:weekly' in content
+    assert 'freq:quarterly' not in content
 
 
 def test_write_void_rdf_with_service_desc():


### PR DESCRIPTION
Closes #101.

The served RDF advertised `pav:version "1.3"` against data built on 2026-08-01. Worth noting the issue understated this: the literal was not a stale 2020 git tag, it tracked a **planning-milestone label** — and then collided with an unrelated 2020 tag of the same name. Either way the one version identifier a consumer sees was meaningless, and pinning a release meant falling back to a commit SHA cross-checked against `void:triples` counts.

## Approach

Separate the two things that were being conflated.

| What | Where | Scheme | Example |
|---|---|---|---|
| The **dataset** — one weekly snapshot | `pav:version` | calendar, derived from the XML export date | `"2026.08.01"` |
| The **software** — this repo | `pav:createdWith` commit URL | git commit | `<…/commit/0eeca9a…>` |

`pav:version` is derived at generation time from the AOP-Wiki XML filename, so it cannot drift again. When the filename carries no parseable date the triple is **omitted rather than guessed** — absent is honest, stale is not. Same for the commit URL outside a checkout.

The commit URL answers the reporter's third suggestion directly: a release is now pinnable from the endpoint alone.

## Also

`dcat:accrualPeriodicity` corrected from `freq:quarterly` to `freq:weekly` on all three subsets. Regeneration has been a Saturday 08:00 UTC cron for some time, so the description was telling consumers to expect refreshes four times less often than they actually happen. The issue flagged this as a possible aside; it was real.

## Verified

17 new tests. End-to-end check that the VoID parses as valid Turtle and the documented SPARQL query returns exactly one row. COMPAT masks added (patterns 6 and 7) since both values now vary per run — that gate is `workflow_dispatch`-only, so weekly CI is unaffected.

`pipeline_monolith.py` is deliberately untouched to preserve its parity baseline. No data files are touched.