### PR TITLE
fix(gene_mapper): stoplist seven single-claimant domain abbreviations

### DIFF
--- a/src/aopwiki_rdf/mapping/gene_mapper.py
+++ b/src/aopwiki_rdf/mapping/gene_mapper.py
@@ -174,10 +174,43 @@ ROMAN_NUMERAL_PATTERN = re.compile(r'\b[IVX]+\b')
 # previous symbol of two other genes; TH is both thyroid hormone and tyrosine
 # hydroxylase), so they are handled by ownership resolution and the short-token
 # rule below, which can still admit them where the context supports it.
+#
+# Second batch, added after a survey of the published 97191db release. Each was
+# found by ranking genes on regex-vs-NER disagreement (see issue #109) and then
+# read in context across the 1,360 KE/KER texts; the counts below are
+# occurrences in that corpus, every one of which was the non-gene reading:
+#
+#   T3       188x  triiodothyronine        alias of SLC25A5
+#   T2        15x  diiodothyronine         alias of SLC25A5
+#   LPS       19x  lipopolysaccharide      previous symbol of IRF6
+#   HCC       31x  hepatocellular carcinoma  alias of HYCC1
+#   PND        9x  postnatal day           alias of NPPA
+#   CCL        6x  C-C chemokine family prefix  alias of CRYGEP
+#   BPA        5x  bisphenol A             alias of DST
+#
+# These seven are the ones that ownership resolution cannot reach, because each
+# is claimed by exactly ONE gene and so is never contested. Tokens with several
+# claimants and no approved-symbol owner -- E2, EMT, ERK, p38, ALP, G2, AP-1 --
+# are already retired by build_token_owners and are deliberately left out rather
+# than listed redundantly.
+#
+# Also deliberately NOT here, having been checked and rejected:
+#   TPO, CA1, DBP  approved symbols of real genes; stoplisting them would drop
+#                  legitimate mentions. CA1 (carbonic anhydrase 1 vs the
+#                  hippocampal CA1 field) is genuinely ambiguous and needs a
+#                  context rule, not a stoplist. DBP does not occur in the
+#                  corpus at all.
 DOMAIN_ABBREVIATION_STOPLIST = {
     'ROS',
     'ECM',
     'spatial',
+    'T3',
+    'T2',
+    'LPS',
+    'HCC',
+    'PND',
+    'CCL',
+    'BPA',
 }
 
 # A short token is only read as a gene when the surrounding prose is talking

--- a/tests/unit/test_gene_precision.py
+++ b/tests/unit/test_gene_precision.py
@@ -116,6 +116,92 @@ def test_ordinary_english_word_does_not_match_TBATA():
     assert find(text, TBATA) == set()
 
 
+# --- Second stoplist batch (issue #109) ------------------------------------
+#
+# These seven are single-claimant tokens, so ownership resolution never sees
+# them as contested and cannot retire them. Contexts below are taken from the
+# published 97191db corpus. Each pairs a rejection with a proof that the
+# claiming gene is still reachable by its approved symbol.
+
+SLC25A5 = {'10991': ['SLC25A5', 'solute carrier family 25 member 5', 'T2', 'T3']}
+IRF6 = {'6121': ['IRF6', 'interferon regulatory factor 6', 'LPS']}
+HYCC1 = {'24587': ['HYCC1', 'hyccin PI4KA lipid kinase complex subunit 1', 'HCC']}
+NPPA = {'7939': ['NPPA', 'natriuretic peptide A', 'PND']}
+CRYGEP = {'2412': ['CRYGEP', 'crystallin gamma E, pseudogene', 'CCL']}
+DST = {'1090': ['DST', 'dystonin', 'BPA']}
+
+
+def test_thyroid_hormones_do_not_match_SLC25A5():
+    """T3/T2 are thyronines throughout the corpus, never the transporter.
+
+    T3 alone occurs 188 times, which made SLC25A5 one of the most widely
+    asserted genes in the release.
+    """
+    text = ('The two major thyroid hormones are triiodothyronine (T3) and '
+            'thyroxine (T4); deiodination of rT3 yields 3,3-T2.')
+    assert find(text, SLC25A5) == set()
+
+
+def test_lipopolysaccharide_does_not_match_IRF6():
+    text = ('Lipopolysaccharide (LPS) from the bacteria binds to TLR4 and '
+            'drives expression of pro-inflammatory cytokines.')
+    assert find(text, IRF6) == set()
+
+
+def test_hepatocellular_carcinoma_does_not_match_HYCC1():
+    text = ('Hepatocellular carcinoma (HCC) is a primary cancer of the '
+            'hepatocytes.')
+    assert find(text, HYCC1) == set()
+
+
+def test_postnatal_day_does_not_match_NPPA():
+    text = ('Inhibitory synapses cannot be found prior to PND 18, after which '
+            'expression increases steadily.')
+    assert find(text, NPPA) == set()
+
+
+def test_chemokine_family_prefix_does_not_match_CRYGEP():
+    text = ('Enhanced levels of the C-C motif chemokine ligand (CCL) family '
+            'were observed, including CCL-2 protein.')
+    assert find(text, CRYGEP) == set()
+
+
+def test_bisphenol_a_does_not_match_DST():
+    text = ('Bisphenol A (BPA) exposure altered receptor expression in '
+            'exposed animals.')
+    assert find(text, DST) == set()
+
+
+def test_second_batch_genes_still_match_their_approved_symbols():
+    """The whole batch must cost no genuine mentions.
+
+    A stoplist entry rejects one alias, not the gene -- each of these texts
+    names the gene by its approved symbol and must still be found.
+
+    None of these strings may begin with the symbol: the precision dictionary
+    matches delimiter-wrapped variants, so a token opening a text has no
+    leading delimiter and can never match (issue #104). That is a pre-existing
+    recall gap, unrelated to the stoplist.
+    """
+    assert find('Expression of SLC25A5 was reduced.', SLC25A5) == {'hgnc:10991'}
+    assert find('The IRF6 gene was upregulated.', IRF6) == {'hgnc:6121'}
+    assert find('Levels of HYCC1 protein fell.', HYCC1) == {'hgnc:24587'}
+    assert find('Transcription of NPPA increased.', NPPA) == {'hgnc:7939'}
+    assert find('The DST gene was altered.', DST) == {'hgnc:1090'}
+
+
+def test_gene_context_cue_does_not_rescue_a_stoplisted_token():
+    """The gap this batch closes.
+
+    The short-token rule admits a token whenever a cue word is nearby, and
+    toxicology prose about a stressor almost always also says "expression" or
+    "receptor" -- so the cue test alone let every one of these through.
+    """
+    text = ('LPS-induced expression of the receptor protein increased '
+            'following exposure.')
+    assert find(text, IRF6) == set()
+
+
 def test_stoplisted_gene_still_matches_its_real_symbol():
     """Stoplisting the alias 'ROS' must not cost us genuine ROS1 mentions."""
     text = 'The ROS1 gene was found to be overexpressed in treated cells.'


### PR DESCRIPTION
Extends `DOMAIN_ABBREVIATION_STOPLIST` with seven tokens, following the verify-before-adding discipline #107 established. Partially addresses #109.

## Why these seven, and not the others

The candidates came from ranking genes on regex-vs-NER disagreement across the published `97191db` release (#109), then reading every occurrence in the 1,360 KE/KER texts. Sorting the survivors by *why* they survive turned out to be the useful step:

**Added — single-claimant tokens, which ownership resolution cannot reach.** `build_token_owners` only acts on *contested* tokens. Each of these is claimed by exactly one gene, so there is no contest, nothing is retired, and the only remaining defence is the short-token rule — which admits the token whenever a gene-context cue sits nearby.

| token | corpus | what it means | claimed by |
|---|---:|---|---|
| `T3` | 188x | triiodothyronine | SLC25A5 |
| `T2` | 15x | diiodothyronine | SLC25A5 |
| `LPS` | 19x | lipopolysaccharide | IRF6 |
| `HCC` | 31x | hepatocellular carcinoma | HYCC1 |
| `PND` | 9x | postnatal day | NPPA |
| `CCL` | 6x | C-C chemokine family prefix | CRYGEP |
| `BPA` | 5x | bisphenol A | DST |

Every occurrence of every one of these is the non-gene reading. `T3` at 188 occurrences made SLC25A5 one of the most widely asserted genes in the release.

**Not added — already retired by ownership resolution.** `E2`, `EMT`, `ERK`, `p38`, `ALP`, `G2`, `AP-1` all have several claimants and no approved-symbol owner, so `build_token_owners` already drops them. Listing them again would be redundant. Worth noting that `ERK` and `p38` are the interesting case: they are *also* aliases of MAPK1 and MAPK14, so they are ambiguous rather than always-wrong, and stoplisting them would have cost real mentions. Ownership resolution handles them correctly today.

**Not added — checked and rejected.** `TPO`, `CA1` and `DBP` are approved symbols of real genes. Stoplisting them would drop legitimate mentions. `CA1` (carbonic anhydrase 1 vs the hippocampal CA1 field) is genuinely ambiguous and wants a context rule rather than a stoplist; `DBP` does not occur in the corpus at all.

## The gap this closes

The short-token rule rejects a short alias only when no gene-context cue is nearby. In toxicology prose the cue is nearly always there, because text about a stressor usually also mentions expression or a receptor:

```
"LPS-induced expression of the receptor protein increased following exposure."
```

`expression`, `receptor` and `protein` all satisfy the cue test, so `LPS` was admitted and IRF6 asserted. There is a regression test for exactly this.

Rejection for these seven is now unconditional rather than contingent on incidental nearby wording.

## Measured effect

Running the matcher over the corpus with and without the change, restricted to the six affected genes:

| gene | entities before | after | removed |
|---|---:|---:|---:|
| SLC25A5 | 11 | 0 | 11 |
| HYCC1 | 1 | 0 | 1 |
| IRF6 | 1 | 0 | 1 |
| NPPA, CRYGEP, DST | 0 | 0 | 0 |
| **total** | **13** | **0** | **13** |

Two honest caveats on that number. It is small because #107's other filters already catch most of these occurrences — the stoplist closes the residual cases where a cue word happens to sit nearby. And it will vary release to release precisely because it depends on incidental phrasing, which is the argument for making the rejection deterministic.

**No true positives are lost.** None of the six genes is named legitimately anywhere in the corpus — not by approved symbol, not by any other alias (checked `SLC25A5`/`ANT2`, `IRF6`, `HYCC1`/`FAM126A`, `NPPA`/`ANP`, `CRYGEP`, `DST`/`BPAG1`/`dystonin`: zero occurrences each). Every association these genes received was a false positive.

## Tests

Eight new tests in `test_gene_precision.py`, in the existing style: one rejection per token, one proving the whole batch still matches its approved symbols, and one for the cue-word gap above. Full unit suite passes.

`test_orchestrator.py::test_orchestrator_line_count` fails on this branch, but it fails identically on `master` (`pipeline.py` is 657 lines against a 650 limit) and is unrelated.

## Note for the QC gate

This is a deliberate drop in gene associations, so the QC workflow needs `expect_gene_change: drop` — same handling as #107. The drop is far smaller here.
