### PR TITLE
perf(gene_mapper): replace the nested-loop matcher with an Aho-Corasick automaton

### DIFF
--- a/docs/conversion.md
+++ b/docs/conversion.md
@@ -58,13 +58,23 @@ Gene clusters (symbols containing `@`) are excluded.
 
 **Example:** For gene TP53 (HGNC:11998) with aliases including "p53" and "tumor protein p53", Stage 1 searches the KE description text for any of these terms. If "p53" appears anywhere in the text, the gene passes screening.
 
-### Stage 2: Precision Matching (genedict2)
+### Stage 2: Boundary-bounded matching (Aho-Corasick)
 
-The precision dictionary `genedict2` extends each alias with punctuation-delimited variants. For each alias, all combinations of leading and trailing delimiter characters from the set `[' ', '(', ')', '[', ']', ',', '.']` are generated.
+Matching uses an Aho-Corasick automaton (`mapping/automaton.py`) built once per run from `{token: gene}`. Each text is scanned **once**, in time proportional to its length rather than to the size of the dictionary.
 
-**How it works:** After Stage 1 passes a gene, Stage 2 checks whether any punctuation-bounded variant from `genedict2` appears in the text. This prevents matching gene symbols that are substrings of longer words.
+A match counts only when the characters immediately before and after it are delimiters, from the set `[' ', '(', ')', '[', ']', ',', '.']` — so `AR` matches in `"(AR)"` but not inside `ARID1A`. **The start and end of the text also count as boundaries.**
 
-**Example:** For a gene with symbol "A", `genedict2` generates variants like `" A "`, `" A,"`, `"(A)"`, `" A."`, etc. This prevents matching the letter "A" when it appears as part of normal English text, only matching when it appears as a standalone term bounded by punctuation or spaces.
+This replaced a dictionary named `genedict2` that pre-expanded every token into all 49 combinations of leading and trailing delimiter, and a loop that tested all ~45,000 genes against every text.
+
+| | expanded dictionary + loop | automaton |
+|---|---:|---:|
+| dictionary build | 37 s, 510 MB peak | 1.0 s, 23 MB peak |
+| stored entries | 7,383,026 variants | 146,633 tokens / 563,036 states |
+| corpus scan (2,737 texts) | 505 s | 2.8 s |
+
+`genedict2` is no longer built. `build_gene_dicts(..., build_precision_dict=True)` still produces it for anything that wants the old shape.
+
+Because the automaton reports **every** token spanning a position, contested-token resolution is applied when the token index is built rather than per match — one token maps to at most one gene by construction.
 
 ### Stage 3: False Positive Filtering
 
@@ -150,9 +160,13 @@ Genes written by their approved symbol are unaffected: AHR holds at 36 occurrenc
 
 Because BERN2 output is unioned in, the published drop is smaller than the regex drop: of the 2,812 regex associations removed, 1,507 are for genes BERN2 finds independently.
 
-### Known recall gap
+### Recall gap at text boundaries (fixed)
 
-Every `genedict2` variant has the form delimiter + token + delimiter, so a token that **opens** a text has no leading delimiter to match against and is missed entirely. `tests/unit/test_gene_precision.py` pins this as a strict `xfail`. It predates the precision work; fixing it changes recall and needs its own measurement.
+Every `genedict2` variant had the form delimiter + token + delimiter, so a token that **opened** a text had no leading delimiter to match against and was missed entirely, however unambiguous it was. The automaton treats the text edges as boundaries, closing this.
+
+Measured effect on the full corpus: 3,927 → 4,057 gene associations (+3.3%) and 1,035 → 1,046 distinct genes. Two genes lost a match, both correctly — `NPAT` was matching on `E14` (embryonic day 14) and `H2AC20` on `H2A` (the histone family, not that specific gene).
+
+The context window used by the short-token filter is also snapped outward to whole words. A fixed character window could sever a cue and flip the verdict on a single character: one observed match had `over-expression` truncated to `over-expressio`, admitting `STZ` (streptozotocin) as the gene `ST3GAL4`.
 
 ## BERN2 NER+EL Gene Enrichment
 

--- a/src/aopwiki_rdf/mapping/automaton.py
+++ b/src/aopwiki_rdf/mapping/automaton.py
@@ -1,0 +1,140 @@
+"""Aho-Corasick automaton for gene-name matching.
+
+Replaces a nested loop that tested all ~45,000 genes against every text, using a
+``genedict2`` of every token pre-expanded with all 49 combinations of leading and
+trailing delimiter -- 7.4 million materialised strings, and a scan cost
+proportional to (genes x tokens x texts).
+
+The automaton scans each text ONCE, in time proportional to the text length
+regardless of dictionary size, and stores each token once.
+
+Implemented in pure Python deliberately: ``pyahocorasick`` is faster, but this
+runs in the weekly production pipeline and a C extension is a build-time failure
+mode the pipeline does not currently have. The dictionary is built once per run
+and the corpus is small enough that the constant factor does not dominate.
+
+Boundary semantics
+------------------
+A match counts only when the characters immediately before and after it are
+delimiters. The delimiter set is exactly the one ``genedict2`` enumerated --
+space, parens, brackets, comma, period -- so results are unchanged, EXCEPT that
+the start and end of the text now count as boundaries.
+
+That difference is the point: every ``genedict2`` variant was
+delimiter+token+delimiter, so a token opening a text had no leading delimiter to
+match against and was missed entirely, no matter how unambiguous it was. It was
+pinned as a strict xfail in tests/unit/test_gene_precision.py.
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Exactly the delimiters genedict2 enumerated. Kept identical rather than
+# widened to \W so this change is a pure structural swap: broadening what counts
+# as a boundary (to catch "TP53-mediated", say) would alter recall and belongs in
+# its own measured change.
+DELIMITERS = frozenset(' ()[],.')
+
+
+def _is_boundary(text: str, index: int) -> bool:
+    """True when ``index`` is outside the text or holds a delimiter."""
+    if index < 0 or index >= len(text):
+        return True  # start/end of text -- the gap the old expansion could not express
+    return text[index] in DELIMITERS
+
+
+class GeneAutomaton:
+    """Aho-Corasick automaton mapping token occurrences to gene IDs.
+
+    Built from ``{token: gene_key}``. Tokens resolved to ``None`` by contested-
+    token resolution are simply not added, so retired tokens cost nothing at
+    scan time.
+    """
+
+    __slots__ = ('_goto', '_fail', '_output', '_token_len', '_size')
+
+    def __init__(self, token_owners: dict):
+        # Node 0 is the root. Parallel arrays keep this compact: a dict per node
+        # for transitions, plus flat lists for fail links and outputs.
+        self._goto = [{}]
+        self._fail = [0]
+        self._output = [None]   # node -> (token_length, gene_key) or None
+        self._token_len = 0
+        self._size = 0
+
+        for token, gene_key in token_owners.items():
+            if gene_key is None or not token:
+                continue
+            self._add(token, gene_key)
+
+        self._build_failure_links()
+        logger.info(
+            "Gene automaton: %d tokens over %d states",
+            self._size, len(self._goto),
+        )
+
+    def _add(self, token: str, gene_key: str) -> None:
+        node = 0
+        for char in token:
+            nxt = self._goto[node].get(char)
+            if nxt is None:
+                nxt = len(self._goto)
+                self._goto.append({})
+                self._fail.append(0)
+                self._output.append(None)
+                self._goto[node][char] = nxt
+            node = nxt
+        # A token claimed twice would be a bug in ownership resolution; keep the
+        # first so behaviour is deterministic rather than dict-order dependent.
+        if self._output[node] is None:
+            self._output[node] = (len(token), gene_key)
+            self._size += 1
+
+    def _build_failure_links(self) -> None:
+        """Standard BFS construction of failure links."""
+        queue = []
+        for node in self._goto[0].values():
+            self._fail[node] = 0
+            queue.append(node)
+
+        head = 0
+        while head < len(queue):
+            current = queue[head]
+            head += 1
+            for char, target in self._goto[current].items():
+                queue.append(target)
+                state = self._fail[current]
+                while state and char not in self._goto[state]:
+                    state = self._fail[state]
+                self._fail[target] = (
+                    self._goto[state][char] if char in self._goto[state] else 0
+                )
+
+    def find(self, text: str):
+        """Yield ``(start, end, gene_key)`` for every delimiter-bounded match.
+
+        Overlapping matches are all reported -- the caller decides which to keep.
+        This is what removes the need for a separate contested-token pass: an
+        automaton naturally surfaces every token spanning a position, where the
+        old screen-then-confirm loop could only see one gene at a time.
+        """
+        node = 0
+        for index, char in enumerate(text):
+            while node and char not in self._goto[node]:
+                node = self._fail[node]
+            node = self._goto[node].get(char, 0)
+
+            # Walk the failure chain so shorter tokens ending here are not lost.
+            state = node
+            while state:
+                entry = self._output[state]
+                if entry is not None:
+                    length, gene_key = entry
+                    start = index - length + 1
+                    if _is_boundary(text, start - 1) and _is_boundary(text, index + 1):
+                        yield start, index + 1, gene_key
+                state = self._fail[state]
+
+    def __len__(self) -> int:
+        return self._size

--- a/src/aopwiki_rdf/mapping/gene_mapper.py
+++ b/src/aopwiki_rdf/mapping/gene_mapper.py
@@ -13,6 +13,7 @@ import time
 
 import requests
 
+from aopwiki_rdf.mapping.automaton import GeneAutomaton
 from aopwiki_rdf.mapping.bridgedb import batch_xrefs_gene
 
 logger = logging.getLogger(__name__)
@@ -28,13 +29,21 @@ MIN_BRIDGEDB_SUCCESS_RATE = 50.0
 # Section A: Gene dictionary building
 # ---------------------------------------------------------------------------
 
-def build_gene_dicts(hgnc_file_path: str) -> tuple[dict, dict, dict]:
+def build_gene_dicts(hgnc_file_path: str,
+                     build_precision_dict: bool = False
+                     ) -> tuple[dict, dict, dict]:
     """Parse HGNC file into genedict1 (screening), genedict2 (precision), and symbol_lookup.
 
     Parameters
     ----------
     hgnc_file_path : str
         Path to the HGNCgenes.txt file.
+    build_precision_dict : bool
+        Whether to materialise ``genedict2``, the delimiter-expanded variants.
+        Defaults to False: the automaton expresses those boundaries directly, so
+        production no longer reads it, and building it meant holding 7.4 million
+        strings (~0.5 GB) that nothing consumed. Kept as an opt-in because the
+        shape is still part of the published return signature.
 
     Returns
     -------
@@ -88,10 +97,11 @@ def build_gene_dicts(hgnc_file_path: str) -> tuple[dict, dict, dict]:
                 if not item == '':
                     for name in item.split(', '):
                         genedict1[hgnc_id].append(name)
-            for item in genedict1[hgnc_id]:
-                for s1 in symbols:
-                    for s2 in symbols:
-                        genedict2[hgnc_id].append((s1 + item + s2))
+            if build_precision_dict:
+                for item in genedict1[hgnc_id]:
+                    for s1 in symbols:
+                        for s2 in symbols:
+                            genedict2[hgnc_id].append((s1 + item + s2))
 
     hgnc_file.close()
     logger.info(f"Gene mapping setup: {len(genedict2)} genes included for mappings")
@@ -155,6 +165,41 @@ def build_token_owners(genedict1: dict, symbol_lookup: dict) -> dict:
         f"{retired} retired as unresolvable"
     )
     return owners
+
+
+def build_token_index(genedict1: dict, symbol_lookup: dict) -> dict:
+    """Return ``{token: gene_key}`` for every token, contests already resolved.
+
+    The automaton needs one owner per token up front, where the old loop
+    resolved contests per match. Uncontested tokens map to their only claimant;
+    contested ones go to their approved-symbol owner, or are dropped entirely
+    when no reading is defensible -- the same rule :func:`build_token_owners`
+    applies, just materialised for the whole dictionary.
+    """
+    claims: dict[str, set] = {}
+    for gene_key, tokens in genedict1.items():
+        for token in tokens:
+            stripped = token.strip()
+            if stripped:
+                claims.setdefault(stripped, set()).add(gene_key)
+
+    index = {}
+    retired = 0
+    for token, gene_keys in claims.items():
+        if len(gene_keys) == 1:
+            index[token] = next(iter(gene_keys))
+            continue
+        symbol_owners = [k for k in gene_keys if symbol_lookup.get(k) == token]
+        if len(symbol_owners) == 1:
+            index[token] = symbol_owners[0]
+        else:
+            retired += 1
+
+    logger.info(
+        f"Gene mapping setup: {len(index)} tokens indexed, "
+        f"{retired} contested tokens retired as unresolvable"
+    )
+    return index
 
 
 # ---------------------------------------------------------------------------
@@ -229,6 +274,32 @@ def _has_gene_context(context: str) -> bool:
     return bool(_GENE_CONTEXT_PATTERN.search(context))
 
 
+CONTEXT_RADIUS = 50
+
+
+def _context_window(text: str, start: int, end: int,
+                    radius: int = CONTEXT_RADIUS) -> str:
+    """Return roughly ``radius`` characters either side, snapped to whole words.
+
+    A fixed character window can sever a cue word and flip the verdict on one
+    character: an observed match had "over-expression" truncated to
+    "over-expressio", losing the `expression` cue and with it the decision.
+    Extending to the nearest whitespace outside the window means a cue either
+    falls in range or does not, rather than depending on where the arithmetic
+    happened to land.
+    """
+    left = max(0, start - radius)
+    right = min(len(text), end + radius)
+
+    # Walk outward to whitespace so partially-included words are made whole.
+    while left > 0 and not text[left - 1].isspace():
+        left -= 1
+    while right < len(text) and not text[right].isspace():
+        right += 1
+
+    return text[left:right]
+
+
 def _is_false_positive(gene_key: str, matched_alias: str,
                        matched_text_context: str,
                        symbol_lookup: dict | None = None
@@ -301,12 +372,13 @@ def _is_false_positive(gene_key: str, matched_alias: str,
 def _map_genes_in_text(text: str, genedict1: dict, hgnc_list: list,
                        genedict2: dict | None = None,
                        token_owners: dict | None = None,
-                       symbol_lookup: dict | None = None) -> list[str]:
-    """Enhanced three-stage gene mapping algorithm with false positive filtering.
+                       symbol_lookup: dict | None = None,
+                       automaton=None) -> list[str]:
+    """Find gene mentions in a text and return their HGNC IDs.
 
-    Stage 1: Screen with genedict1 (basic gene names)
-    Stage 2: Match with genedict2 (punctuation-delimited variants) with precision
-    Stage 3: Resolve contested tokens, then apply false positive filters
+    Scans the text once with an Aho-Corasick automaton, then applies the
+    false-positive filters to each delimiter-bounded match. Replaces a loop that
+    tested every gene in the dictionary against every text.
 
     Parameters
     ----------
@@ -314,132 +386,79 @@ def _map_genes_in_text(text: str, genedict1: dict, hgnc_list: list,
         Text to scan for gene mentions.
     genedict1 : dict
         Screening dictionary (numeric_hgnc_id -> [symbol, name, aliases...]).
+        Used to build an automaton when one is not supplied.
     hgnc_list : list
         Global list of found HGNC IDs (mutated in place).
     genedict2 : dict, optional
-        Precision dictionary (numeric_hgnc_id -> punctuation-delimited variants).
+        Accepted and ignored. The delimiter-expanded dictionary it held is what
+        the automaton makes unnecessary; the parameter remains so existing
+        callers keep working.
     token_owners : dict, optional
-        token -> owning HGNC ID (or None) from :func:`build_token_owners`. When
-        omitted, contested tokens are left unresolved and every claiming gene
-        matches -- the pre-existing behaviour, kept so callers that have not
-        been updated still work.
+        Contested-token resolution, applied when building an automaton here.
     symbol_lookup : dict, optional
-        numeric_hgnc_id -> approved symbol, passed through for log clarity.
+        numeric_hgnc_id -> approved symbol, used by the short-token filter.
+    automaton : GeneAutomaton, optional
+        Prebuilt automaton. Pass this in loops -- constructing one per text
+        rebuilds the whole dictionary and is far slower than the code it
+        replaced.
 
     Returns
     -------
     list[str]
         List of found HGNC IDs (e.g., ['hgnc:1100']).
     """
-    if not text or not genedict1:
+    if not text or (automaton is None and not genedict1):
         return []
+
+    if automaton is None:
+        # Convenience path for callers holding only the raw dicts (tests,
+        # ad-hoc use). Production builds the automaton once per run.
+        index = build_token_index(genedict1, symbol_lookup or {})
+        if token_owners:
+            for token, owner in token_owners.items():
+                if owner is None:
+                    index.pop(token, None)
+                else:
+                    index[token] = owner
+        automaton = GeneAutomaton(index)
 
     found_genes = []
     start_time = time.time()
-    genes_checked = 0
 
-    for gene_key in genedict1:
-        genes_checked += 1
+    for start, end, gene_key in automaton.find(text):
+        hgnc_id = 'hgnc:' + gene_key
+        if hgnc_id in found_genes:
+            continue
 
-        # Stage 1: Screen with genedict1
-        a = 0
-        stage1_matched_alias = None
-        for item in genedict1[gene_key]:
-            if item in text:
-                a = 1
-                stage1_matched_alias = item
-                break
+        matched_alias = text[start:end]
+        context = _context_window(text, start, end)
 
-        # Stage 2: If Stage 1 passes, use genedict2 for precise matching
-        if a == 1:
-            hgnc_id = 'hgnc:' + gene_key
+        is_fp, fp_reason = _is_false_positive(
+            gene_key, matched_alias, context, symbol_lookup
+        )
+        if is_fp:
+            # Only this occurrence is rejected. Another mention of the same gene
+            # elsewhere in the text may still carry the context it needs.
+            logger.debug(
+                f"Filtered false positive: {gene_key} "
+                f"(alias '{matched_alias}') - {fp_reason}"
+            )
+            continue
 
-            if genedict2 and gene_key in genedict2:
-                for item in genedict2[gene_key]:
-                    if item in text and hgnc_id not in found_genes:
-                        # Stage 3: False positive filtering
-                        match_index = text.find(item)
-                        context_start = max(0, match_index - 50)
-                        context_end = min(len(text), match_index + len(item) + 50)
-                        context = text[context_start:context_end]
-
-                        # Every genedict2 variant is s1 + token + s2 with both
-                        # sentinels non-empty, so it is always >= 3 chars and
-                        # this strip is the only reachable case.
-                        matched_alias = item.strip(' ()[],.')
-
-                        owner = token_owners.get(matched_alias, gene_key) if token_owners else gene_key
-                        if owner != gene_key:
-                            logger.debug(
-                                f"Skipped contested token '{matched_alias}' for "
-                                f"{gene_key}: owned by {owner or 'no gene'}"
-                            )
-                            # Another variant of this gene may still match
-                            # legitimately, so keep scanning rather than
-                            # abandoning the gene.
-                            continue
-
-                        is_fp, fp_reason = _is_false_positive(
-                            gene_key, matched_alias, context, symbol_lookup
-                        )
-
-                        if is_fp:
-                            logger.debug(
-                                f"Filtered false positive: {gene_key} "
-                                f"(alias '{matched_alias}') - {fp_reason}"
-                            )
-                            # Only this variant is rejected. Abandoning the gene
-                            # here (the previous behaviour) meant a text
-                            # containing both 'ROS' and 'ROS1' could lose the
-                            # legitimate ROS1 match, depending purely on which
-                            # variant genedict2 happened to list first.
-                            continue
-
-                        found_genes.append(hgnc_id)
-                        if hgnc_id not in hgnc_list:
-                            hgnc_list.append(hgnc_id)
-                        break
-            else:
-                # Fallback to genedict1-only matching
-                owner = (
-                    token_owners.get(stage1_matched_alias, gene_key)
-                    if token_owners else gene_key
-                )
-                if owner != gene_key:
-                    logger.debug(
-                        f"Skipped contested token '{stage1_matched_alias}' for "
-                        f"{gene_key}: owned by {owner or 'no gene'}"
-                    )
-                    continue
-
-                is_fp, fp_reason = _is_false_positive(
-                    gene_key, stage1_matched_alias, text, symbol_lookup
-                )
-
-                if not is_fp and hgnc_id not in found_genes:
-                    found_genes.append(hgnc_id)
-                    if hgnc_id not in hgnc_list:
-                        hgnc_list.append(hgnc_id)
-                elif is_fp:
-                    logger.debug(
-                        f"Filtered false positive: {gene_key} "
-                        f"(alias '{stage1_matched_alias}') - {fp_reason}"
-                    )
+        found_genes.append(hgnc_id)
+        if hgnc_id not in hgnc_list:
+            hgnc_list.append(hgnc_id)
 
     elapsed = time.time() - start_time
-    precision_note = (
-        " (using enhanced precision filtering)" if genedict2
-        else " (genedict1 fallback)"
-    )
     if elapsed > 1.0:
         logger.info(
-            f"SLOW gene mapping: {elapsed:.2f}s, {genes_checked} genes, "
-            f"{len(found_genes)} genes found, text_len={len(text)}{precision_note}"
+            f"SLOW gene mapping: {elapsed:.2f}s, {len(found_genes)} genes "
+            f"found, text_len={len(text)}"
         )
     elif found_genes:
         logger.debug(
             f"Gene mapping: {elapsed:.2f}s, {len(found_genes)} genes found, "
-            f"text_len={len(text)}{precision_note}"
+            f"text_len={len(text)}"
         )
 
     return found_genes
@@ -478,6 +497,17 @@ def map_genes_in_entities(kedict: dict, kerdict: dict, genedict1: dict,
     """
     hgnclist = []
 
+    # One automaton for the whole corpus. Building it per text would rebuild the
+    # entire dictionary each time and be far slower than the loop this replaces.
+    index = build_token_index(genedict1, symbol_lookup or {})
+    if token_owners:
+        for token, owner in token_owners.items():
+            if owner is None:
+                index.pop(token, None)
+            else:
+                index[token] = owner
+    automaton = GeneAutomaton(index)
+
     # --- Key Events ---
     logger.info("Starting gene mapping on Key Events (this may take a minute)...")
     ke_start_time = time.time()
@@ -490,7 +520,7 @@ def map_genes_in_entities(kedict: dict, kerdict: dict, genedict1: dict,
             description_text = kedict[ke.get('id')]['dc:description']
             found_genes = _map_genes_in_text(
                 description_text, genedict1, hgnclist, genedict2,
-                token_owners, symbol_lookup,
+                token_owners, symbol_lookup, automaton,
             )
             if found_genes:
                 kedict[ke.get('id')]['edam:data_1025'] = found_genes
@@ -549,6 +579,7 @@ def map_genes_in_entities(kedict: dict, kerdict: dict, genedict1: dict,
             description_genes = _map_genes_in_text(
                 kerdict[ker.get('id')]['dc:description'],
                 genedict1, hgnclist, genedict2, token_owners, symbol_lookup,
+                automaton,
             )
             all_found_genes.extend(description_genes)
 

--- a/tests/unit/test_automaton.py
+++ b/tests/unit/test_automaton.py
@@ -1,0 +1,116 @@
+"""Tests for the Aho-Corasick gene matcher (#104)."""
+
+import pytest
+
+from aopwiki_rdf.mapping.automaton import DELIMITERS, GeneAutomaton, _is_boundary
+from aopwiki_rdf.mapping.gene_mapper import _context_window
+
+SIMPLE = {'TP53': '11998', 'BRCA1': '1100', 'AR': '644'}
+
+
+def matches(text, index=None):
+    return {(t[2], text[t[0]:t[1]]) for t in GeneAutomaton(index or SIMPLE).find(text)}
+
+
+# --- Boundary semantics ----------------------------------------------------
+
+def test_start_of_text_is_a_boundary():
+    """The gap the delimiter-expanded dictionary could not express."""
+    assert ('11998', 'TP53') in matches('TP53 was induced.')
+
+
+def test_end_of_text_is_a_boundary():
+    assert ('11998', 'TP53') in matches('Induction of TP53')
+
+
+def test_whole_text_is_a_single_token():
+    assert ('11998', 'TP53') in matches('TP53')
+
+
+def test_substring_of_a_longer_word_does_not_match():
+    """The reason delimiters exist at all -- ARID1A must not yield AR."""
+    assert matches('ARID1A was measured') == set()
+
+
+@pytest.mark.parametrize('text', [
+    'the TP53 gene', '(TP53)', '[TP53]', 'TP53, and others', 'TP53. Next',
+])
+def test_each_delimiter_bounds_a_match(text):
+    assert ('11998', 'TP53') in matches(text)
+
+
+def test_hyphen_is_not_a_boundary():
+    """Deliberate: the delimiter set is unchanged from the old expansion.
+
+    Widening it (to catch 'TP53-mediated') would alter recall and belongs in its
+    own measured change, not in a structural swap.
+    """
+    assert matches('TP53-mediated apoptosis') == set()
+
+
+def test_delimiter_set_is_the_documented_one():
+    assert DELIMITERS == frozenset(' ()[],.')
+
+
+def test_is_boundary_at_edges():
+    assert _is_boundary('abc', -1)
+    assert _is_boundary('abc', 3)
+    assert not _is_boundary('abc', 1)
+
+
+# --- Multiple and overlapping matches --------------------------------------
+
+def test_all_occurrences_are_reported():
+    found = list(GeneAutomaton(SIMPLE).find('TP53 and later TP53 again'))
+    assert len(found) == 2
+
+
+def test_multiple_distinct_genes_in_one_text():
+    assert matches('TP53 and BRCA1 both respond') == {
+        ('11998', 'TP53'), ('1100', 'BRCA1'),
+    }
+
+
+def test_shorter_token_ending_inside_a_longer_one_is_found():
+    """Failure-link traversal: 'AR' ends inside 'RAR' at the same position."""
+    auto = GeneAutomaton({'RAR': '1', 'AR': '2'})
+    found = {(g, 'x') for _, _, g in auto.find('the RAR receptor')}
+    assert ('1', 'x') in found  # RAR is delimiter-bounded; AR is not
+
+
+# --- Construction ----------------------------------------------------------
+
+def test_retired_tokens_are_not_added():
+    """Contested tokens resolved to None cost nothing at scan time."""
+    auto = GeneAutomaton({'TP53': '11998', 'XX': None})
+    assert len(auto) == 1
+    assert matches('XX was measured', {'TP53': '11998', 'XX': None}) == set()
+
+
+def test_empty_index_matches_nothing():
+    assert list(GeneAutomaton({}).find('TP53 and BRCA1')) == []
+
+
+def test_empty_text_matches_nothing():
+    assert list(GeneAutomaton(SIMPLE).find('')) == []
+
+
+# --- Context window --------------------------------------------------------
+
+def test_context_window_snaps_to_whole_words():
+    """A fixed character window can sever a cue and flip the verdict.
+
+    An observed match had 'over-expression' truncated to 'over-expressio',
+    losing the cue on one character.
+    """
+    text = 'x' * 40 + ' over-expression of STZ diabetic mice was observed'
+    start = text.index('STZ')
+    window = _context_window(text, start, start + 3, radius=15)
+
+    assert 'over-expression' in window
+    assert not window.startswith('ression')
+
+
+def test_context_window_respects_text_edges():
+    text = 'TP53 induced'
+    assert _context_window(text, 0, 4, radius=100) == text

--- a/tests/unit/test_gene_mapper.py
+++ b/tests/unit/test_gene_mapper.py
@@ -45,7 +45,8 @@ def _bridgedb_reachable():
 
 @pytest.mark.skipif(not HGNC_AVAILABLE, reason="HGNCgenes.txt not present")
 def test_build_gene_dicts():
-    result = build_gene_dicts(HGNC_FILE)
+    # genedict2 is opt-in since #104; request it to assert its shape.
+    result = build_gene_dicts(HGNC_FILE, build_precision_dict=True)
 
     # Must return 3-tuple (genedict1, genedict2, symbol_lookup)
     assert len(result) == 3, f"Expected 3-tuple, got {len(result)}-tuple"
@@ -78,7 +79,8 @@ def test_build_gene_dicts():
 @pytest.mark.skipif(not HGNC_AVAILABLE, reason="HGNCgenes.txt not present")
 def test_build_gene_dicts_no_invalid_hgnc_ids():
     """Lines without valid HGNC:NNNN in column 0 are skipped."""
-    genedict1, genedict2, symbol_lookup = build_gene_dicts(HGNC_FILE)
+    genedict1, genedict2, symbol_lookup = build_gene_dicts(
+        HGNC_FILE, build_precision_dict=True)
     # All keys should be purely numeric strings
     for key in genedict1:
         assert key.isdigit(), f"Key '{key}' is not a valid numeric HGNC ID"

--- a/tests/unit/test_gene_precision.py
+++ b/tests/unit/test_gene_precision.py
@@ -62,17 +62,22 @@ def test_contested_token_resolves_to_the_approved_symbol_owner():
     )
 
 
-def test_contested_token_regression_all_three_used_to_match():
-    """Without resolution every claiming gene matches -- the shipped defect."""
-    unresolved = find(
-        'Sustained AR receptor activation follows exposure.', AR_TRIO,
-        resolve=False,
-    )
+def test_contested_token_maps_to_exactly_one_gene():
+    """Resolution is now structural rather than a per-match check.
 
-    assert len(unresolved) > 1
-    assert unresolved > find(
-        'Sustained AR receptor activation follows exposure.', AR_TRIO
-    )
+    The automaton is built from a token index holding one owner per token, so a
+    contested token cannot reach more than one gene by construction -- there is
+    no longer an 'unresolved' mode to compare against, which is the point.
+    """
+    from aopwiki_rdf.mapping.gene_mapper import build_token_index
+
+    g1, _, sym = make_dicts(AR_TRIO)
+    index = build_token_index(g1, sym)
+
+    assert index['AR'] == '644'
+    # FDXR and AREG keep their own unambiguous names.
+    assert index['FDXR'] == '3642'
+    assert index['amphiregulin'] == '651'
 
 
 def test_contested_token_with_no_approved_owner_is_retired():
@@ -159,16 +164,17 @@ def test_short_token_accepted_with_gene_context():
     assert find(text, TH) == {'hgnc:11782'}
 
 
-@pytest.mark.xfail(
-    reason='Pre-existing recall gap: every genedict2 variant is '
-           'delimiter+token+delimiter, so a token starting a text has no '
-           'leading delimiter to match against and is missed entirely. '
-           'Predates the precision work; fixing it changes recall and needs '
-           'its own measurement.',
-    strict=True,
-)
-def test_token_at_start_of_text_is_missed():
+def test_token_at_start_of_text_is_found():
+    """Previously impossible: every genedict2 variant was
+    delimiter+token+delimiter, so a token opening a text had no leading
+    delimiter to match against and was missed however unambiguous it was. The
+    automaton treats the start and end of the text as boundaries."""
     assert find('TH gene expression was reduced.', TH) == {'hgnc:11782'}
+
+
+def test_token_at_end_of_text_is_found():
+    """The same gap applied at the other end when no trailing punctuation."""
+    assert find('Reduced expression of the gene TH', TH) == {'hgnc:11782'}
 
 
 # --- Approved symbols are stronger evidence than aliases -------------------


### PR DESCRIPTION
Closes #104.

The matcher tested all ~45,000 genes against every text, using a `genedict2` that pre-expanded each token into all 49 combinations of leading and trailing delimiter. The automaton scans each text **once**, in time proportional to its length rather than to the size of the dictionary.

## Measured (2,737 KE/KER texts, `aop-wiki-xml-2026-06-18`)

| | loop + genedict2 | automaton |
|---|---:|---:|
| dictionary build | 37 s, 510 MB peak | **1.0 s, 23 MB peak** |
| stored entries | 7,383,026 variants | 146,633 tokens / 563,036 states |
| corpus scan | 505 s | **2.8 s** |

`genedict2` is no longer built — it is precisely what the automaton makes unnecessary, and materialising 7.4M strings nothing consumed was the memory cost. Still available via `build_gene_dicts(build_precision_dict=True)`, since the three-tuple shape is published.

**Pure Python on purpose.** `pyahocorasick` is faster, but this runs in the weekly production pipeline and a C extension is a build-time failure mode the pipeline doesn't currently have. At this corpus size the constant factor doesn't dominate.

## Behaviour

Boundary semantics are unchanged — the delimiter set is exactly the one `genedict2` enumerated — with one deliberate exception: **the start and end of the text now count as boundaries.** Every variant was delimiter+token+delimiter, so a token *opening* a text had no leading delimiter and was missed however unambiguous it was. That was pinned as a strict `xfail`; it is now a passing test.

Effect: **3,927 → 4,057 associations (+3.3%)**, 1,035 → 1,046 distinct genes.

Two genes lost a match. I checked both rather than assuming, and both are correct rejections:

- **NPAT** was matching on `E14` — *embryonic day 14* ("80% decrease at E14")
- **H2AC20** was matching on `H2A` — the histone *family* ("histone H2A, H2B, H3, and H4"), not that gene

No true positive was lost.

## Two things that fell out

Contested-token resolution moves into `build_token_index`, applied once when the index is built rather than per match — because the automaton reports every token spanning a position, one token maps to at most one gene **by construction**.

The filter's context window is now snapped outward to whole words. A fixed character window could sever a cue and flip a verdict on a single character: one observed match had `over-expression` truncated to `over-expressio`, which admitted `STZ` (*streptozotocin*) as the gene ST3GAL4. That fixed 3 of the 5 initial regressions.

## Verified

20 new automaton tests; full unit suite **369 passed**. No data files touched.

Note the published output will move when the next regeneration runs — worth using `expect_gene_change: rise` for that one, since this is a recall gain.