### PR TITLE
feat: rank detector disagreement and filter stressor abbreviations

### DIFF
--- a/.github/workflows/Turtle_File_Quality_Control.yml
+++ b/.github/workflows/Turtle_File_Quality_Control.yml
@@ -191,3 +191,27 @@ jobs:
           # qc-delta-report.json) must not trigger a commit with nothing staged,
           # which exits non-zero and fails the job.
           git diff --staged --quiet || (git commit -m "Update QC status" && git push)
+
+      # Step 7: Detector-disagreement ranking (QC-03, issue #109).
+      # Ranks genes the dictionary asserts on many entities that BERN2 never
+      # confirms -- the signal that surfaces alias collisions (ROS -> ROS1,
+      # BPA -> DST) without waiting for someone to notice one by accident.
+      #
+      # ADVISORY ONLY, never blocking. NER silence is not proof of a false
+      # positive: BERN2 has its own recall gaps and has had zero-output weeks,
+      # so this gates human review and must not drive an automatic drop. Runs
+      # after the delta guard so a genuine data failure surfaces first.
+      - name: Gene detector-disagreement ranking (advisory)
+        if: always()
+        run: |
+          python scripts/detector_disagreement.py \
+            --genes-file data/AOPWikiRDF-Genes.ttl \
+            --report-path gene-disagreement.json || true
+
+      - name: Upload disagreement report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gene-disagreement-report
+          path: gene-disagreement.json
+          if-no-files-found: ignore

--- a/docs/conversion.md
+++ b/docs/conversion.md
@@ -160,6 +160,31 @@ Genes written by their approved symbol are unaffected: AHR holds at 36 occurrenc
 
 Because BERN2 output is unioned in, the published drop is smaller than the regex drop: of the 2,812 regex associations removed, 1,507 are for genes BERN2 finds independently.
 
+### Stressor abbreviations
+
+Chemical stressor abbreviations collide with gene aliases often, and both detectors used to read them as genes: `BPA` (bisphenol A) is an alias of **DST**, and `DBP` (dibutyl phthalate) is the approved symbol of **D-box binding protein**. Two of the most-studied stressors in AOP-Wiki were being asserted as gene mentions.
+
+A token of 4 characters or fewer that sits **immediately** beside exposure language — `BPA exposure`, `exposed to BPA`, `treatment with DBP` — is read as an administered substance rather than a gene.
+
+Two guards keep this from over-reaching:
+
+- **Position matters, not proximity.** In *"AR expression was measured after BPA exposure"* the word `exposure` is within range of both tokens, but only `BPA` is directly followed by it. A window-wide test would discard the legitimate AR match too.
+- **A following head noun cancels it.** In *"exposure to TPO inhibitors"* the administered thing is the inhibitor and `TPO` merely modifies it, so that stays a valid thyroid-peroxidase mention. Without this guard the rule discarded 8 such TPO matches.
+
+Full protein names are exempt entirely — *"leptin treatment"* and *"insulin treatment"* are genuine mentions of those gene products, and an earlier revision of this rule discarded exactly those.
+
+### Finding collisions systematically
+
+`scripts/detector_disagreement.py` ranks genes by how often the dictionary asserts them against how often BERN2 confirms them. A gene asserted on many entities that the context-aware model never confirms is overwhelmingly a collision, because NER declines exactly what a context-free string match cannot.
+
+```bash
+python scripts/detector_disagreement.py --min-regex-entities 10 --max-agreement 0.10
+```
+
+Run against the pre-fix `97191db` release it puts **ROS1 first and TBATA second** — the two clearest collisions, found independently of the manual audit that originally caught them. It runs in the QC workflow as an **advisory** artifact.
+
+This is a **heuristic for review, not ground truth.** NER silence does not prove a false positive: BERN2 has its own recall gaps and has had zero-output weeks. It must gate a human decision, never an automatic drop, and it cannot see collisions both detectors make.
+
 ### Recall gap at text boundaries (fixed)
 
 Every `genedict2` variant had the form delimiter + token + delimiter, so a token that **opened** a text had no leading delimiter to match against and was missed entirely, however unambiguous it was. The automaton treats the text edges as boundaries, closing this.

--- a/scripts/detector_disagreement.py
+++ b/scripts/detector_disagreement.py
@@ -1,0 +1,181 @@
+"""Rank gene mappings by regex/NER detector disagreement (issue #109).
+
+Finding alias collisions has been manual: someone notices that ``ROS`` is
+matching ROS1 and adds it to the stoplist. The published RDF already carries a
+signal that surfaces them automatically.
+
+Both detectors are materialised -- ``:geneDetectedByRegex`` and
+``:geneDetectedByNER``. A gene the dictionary asserts on many entities that
+BERN2 never confirms is overwhelmingly a collision, because a context-aware
+model declines exactly what a context-free string match cannot.
+
+This is a PRECISION HEURISTIC, NOT GROUND TRUTH. NER silence does not prove a
+false positive: BERN2 has its own recall gaps and has had zero-output weeks. The
+ranking exists to gate human review, and must never drive an automatic drop.
+It also cannot see collisions both detectors make.
+
+Usage
+-----
+    python scripts/detector_disagreement.py [--genes-file data/AOPWikiRDF-Genes.ttl]
+                                            [--min-regex-entities 10]
+                                            [--max-agreement 0.10]
+                                            [--report-path gene-disagreement.json]
+"""
+
+import argparse
+import json
+import re
+import sys
+
+DEFAULT_GENES_FILE = "data/AOPWikiRDF-Genes.ttl"
+DEFAULT_REPORT_PATH = "gene-disagreement.json"
+
+# Thresholds chosen to surface the known-good cases (ROS1, TBATA), not tuned.
+DEFAULT_MIN_REGEX_ENTITIES = 10
+DEFAULT_MAX_AGREEMENT = 0.10
+
+_ENTITY_RE = re.compile(r"^(aop\.(?:events|relationships):\d+)", re.MULTILINE)
+_HGNC_RE = re.compile(r"hgnc:(\d+)")
+
+
+def parse_detector_sets(text: str) -> tuple[dict, dict]:
+    """Return ``({gene: {entities}}, {gene: {entities}})`` for regex and NER.
+
+    Parsed with regexes rather than rdflib: this reads one predicate pair out of
+    a 200k-triple file, and a full graph parse costs ~30s for no added accuracy.
+    """
+    regex_hits: dict[str, set] = {}
+    ner_hits: dict[str, set] = {}
+
+    # Split into per-subject blocks, then read each detector predicate's objects.
+    starts = [m.start() for m in _ENTITY_RE.finditer(text)]
+    starts.append(len(text))
+    for i in range(len(starts) - 1):
+        block = text[starts[i]:starts[i + 1]]
+        entity = _ENTITY_RE.match(block).group(1)
+        for predicate, target in (
+            ("geneDetectedByRegex", regex_hits),
+            ("geneDetectedByNER", ner_hits),
+        ):
+            match = re.search(
+                re.escape(predicate) + r"(.*?)(?=;|\.\s*\n)", block, re.S
+            )
+            if not match:
+                continue
+            for gene in _HGNC_RE.findall(match.group(1)):
+                target.setdefault(gene, set()).add(entity)
+
+    return regex_hits, ner_hits
+
+
+def rank_candidates(regex_hits, ner_hits, min_regex_entities, max_agreement):
+    """Return collision candidates, most regex-asserted first."""
+    candidates = []
+    for gene, entities in regex_hits.items():
+        if len(entities) < min_regex_entities:
+            continue
+        confirmed = entities & ner_hits.get(gene, set())
+        agreement = len(confirmed) / len(entities)
+        if agreement <= max_agreement:
+            candidates.append({
+                "gene": f"hgnc:{gene}",
+                "regex_entities": len(entities),
+                "ner_confirmed": len(confirmed),
+                "agreement": round(agreement, 4),
+            })
+    candidates.sort(key=lambda c: (-c["regex_entities"], c["gene"]))
+    return candidates
+
+
+def load_symbols(path="data/HGNCgenes.txt") -> dict:
+    """Return ``{numeric_hgnc_id: (symbol, [aliases])}`` for annotation."""
+    symbols = {}
+    try:
+        with open(path, encoding="utf-8") as handle:
+            for line in handle:
+                parts = line.rstrip("\n").split("\t")
+                if len(parts) > 4 and parts[0].isdigit():
+                    aliases = [
+                        a for a in parts[3].split(", ") + parts[4].split(", ") if a
+                    ]
+                    symbols[parts[0]] = (parts[1], aliases)
+    except OSError:
+        pass  # annotation is a convenience, not a requirement
+    return symbols
+
+
+def format_report(candidates, symbols) -> str:
+    """Render the ranking as a markdown table for a human reviewer."""
+    if not candidates:
+        return "No candidates above threshold.\n"
+
+    lines = [
+        "| gene | symbol | regex entities | NER confirmed | agreement | short aliases |",
+        "|---|---|---:|---:|---:|---|",
+    ]
+    for candidate in candidates:
+        numeric = candidate["gene"].split(":")[1]
+        symbol, aliases = symbols.get(numeric, ("?", []))
+        short = ", ".join(f"`{a}`" for a in aliases if len(a) <= 4) or "—"
+        lines.append(
+            f"| {candidate['gene']} | {symbol} | {candidate['regex_entities']} "
+            f"| {candidate['ner_confirmed']} | {candidate['agreement']:.0%} | {short} |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("--genes-file", default=DEFAULT_GENES_FILE)
+    parser.add_argument("--min-regex-entities", type=int,
+                        default=DEFAULT_MIN_REGEX_ENTITIES)
+    parser.add_argument("--max-agreement", type=float,
+                        default=DEFAULT_MAX_AGREEMENT)
+    parser.add_argument("--report-path", default=DEFAULT_REPORT_PATH)
+    args = parser.parse_args(argv)
+
+    try:
+        with open(args.genes_file, encoding="utf-8") as handle:
+            text = handle.read()
+    except OSError as exc:
+        print(f"ERROR: cannot read {args.genes_file}: {exc}", file=sys.stderr)
+        return 1
+
+    regex_hits, ner_hits = parse_detector_sets(text)
+    if not ner_hits:
+        # Without NER output there is no disagreement to measure. Not an error:
+        # BERN2 is optional and has had zero-output weeks.
+        print("::warning::No :geneDetectedByNER triples found; "
+              "disagreement ranking needs both detectors. Skipping.")
+        return 0
+
+    candidates = rank_candidates(
+        regex_hits, ner_hits, args.min_regex_entities, args.max_agreement,
+    )
+    symbols = load_symbols()
+
+    report = {
+        "min_regex_entities": args.min_regex_entities,
+        "max_agreement": args.max_agreement,
+        "regex_genes": len(regex_hits),
+        "ner_genes": len(ner_hits),
+        "candidate_count": len(candidates),
+        "candidate_pairs": sum(c["regex_entities"] for c in candidates),
+        "candidates": candidates,
+    }
+    with open(args.report_path, "w", encoding="utf-8") as handle:
+        json.dump(report, handle, indent=2)
+
+    print(f"Regex-detected genes: {len(regex_hits)}  NER-detected: {len(ner_hits)}")
+    print(f"Collision candidates (regex >= {args.min_regex_entities} entities, "
+          f"agreement <= {args.max_agreement:.0%}): {len(candidates)} genes, "
+          f"{report['candidate_pairs']} regex-asserted pairs\n")
+    print(format_report(candidates, symbols))
+    print(f"Report written to {args.report_path}")
+    print("\nNOTE: a heuristic for review, not ground truth. NER silence is not "
+          "proof of a false positive -- verify before stoplisting.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/aopwiki_rdf/mapping/gene_mapper.py
+++ b/src/aopwiki_rdf/mapping/gene_mapper.py
@@ -274,6 +274,68 @@ def _has_gene_context(context: str) -> bool:
     return bool(_GENE_CONTEXT_PATTERN.search(context))
 
 
+# Language that marks the token as the thing being ADMINISTERED rather than
+# measured. Chemical stressor abbreviations collide with gene aliases often --
+# BPA (bisphenol A) is an alias of DST, DBP (dibutyl phthalate) is the approved
+# symbol of D-box binding protein -- and both were being read as gene mentions.
+#
+# Matched POSITIONALLY, immediately around the token, not anywhere in the window.
+# That distinction is what makes it safe: in "AR expression was measured after
+# BPA exposure", 'exposure' is present for both tokens, but only BPA is directly
+# followed by it. A window-wide test would discard the legitimate AR match too.
+_STRESSOR_AFTER = re.compile(
+    r'^[\s\-]*(?:exposure|exposures|exposed|treatment|treated|administration|'
+    r'administered|dosing|dosed|injection|injected)\b',
+    re.IGNORECASE,
+)
+_STRESSOR_BEFORE = re.compile(
+    r'\b(?:exposure|exposed|treatment|treated|administration|administered|'
+    r'dosing|dosed|injection|injected)\s+(?:to|with|of)\s*$',
+    re.IGNORECASE,
+)
+
+# How far either side to look for that positional evidence. Deliberately short:
+# it must catch "BPA exposure" without reaching an unrelated clause.
+STRESSOR_PROXIMITY = 24
+
+
+# Only ABBREVIATIONS are treated this way. A full protein name next to exposure
+# language is usually still a real mention of that gene product -- "leptin
+# treatment" and "insulin treatment" are about leptin and insulin, and an
+# earlier revision of this rule discarded exactly those. An abbreviation next to
+# the same words is far more often a chemical: BPA, DBP, TCDD.
+STRESSOR_MAX_TOKEN_LEN = 4
+
+
+# When one of these follows the token, the token is MODIFYING it rather than
+# being the administered substance itself. "exposure to TPO inhibitors" is about
+# thyroid peroxidase -- the inhibitor is what was administered, and TPO is a
+# perfectly good gene mention. Without this guard the rule discarded 8 such TPO
+# matches and read the gene out of its own sentence.
+_STRESSOR_HEAD_NOUN = re.compile(
+    r'^[\s\-]*(?:inhibitor|inhibitors|inhibition|agonist|agonists|antagonist|'
+    r'antagonists|activity|activities|level|levels|protein|proteins|enzyme|'
+    r'enzymes|receptor|receptors|expression|mrna|signalling|signaling|'
+    r'deficien\w*|knockout|null)\b',
+    re.IGNORECASE,
+)
+
+
+def _is_stressor_mention(text: str, start: int, end: int) -> bool:
+    """True when the token reads as an administered substance, not a gene."""
+    if end - start > STRESSOR_MAX_TOKEN_LEN:
+        return False
+
+    after = text[end:end + STRESSOR_PROXIMITY]
+    if _STRESSOR_HEAD_NOUN.match(after):
+        return False
+
+    if _STRESSOR_AFTER.match(after):
+        return True
+    before = text[max(0, start - STRESSOR_PROXIMITY):start]
+    return bool(_STRESSOR_BEFORE.search(before))
+
+
 CONTEXT_RADIUS = 50
 
 
@@ -431,6 +493,16 @@ def _map_genes_in_text(text: str, genedict1: dict, hgnc_list: list,
             continue
 
         matched_alias = text[start:end]
+
+        # Checked before the general filters: this needs the token's position in
+        # the text, which _is_false_positive deliberately does not receive.
+        if _is_stressor_mention(text, start, end):
+            logger.debug(
+                f"Filtered stressor mention: {gene_key} "
+                f"(token '{matched_alias}' reads as an administered substance)"
+            )
+            continue
+
         context = _context_window(text, start, end)
 
         is_fp, fp_reason = _is_false_positive(

--- a/tests/unit/test_detector_disagreement.py
+++ b/tests/unit/test_detector_disagreement.py
@@ -1,0 +1,125 @@
+"""Tests for detector-disagreement ranking and the stressor filter (#109)."""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'scripts'))
+
+from detector_disagreement import (  # noqa: E402
+    parse_detector_sets,
+    rank_candidates,
+)
+from aopwiki_rdf.mapping.gene_mapper import (  # noqa: E402
+    _is_stressor_mention,
+    _map_genes_in_text,
+)
+
+TTL = """
+aop.events:1 a aopo:KeyEvent ;
+\t:geneDetectedByRegex hgnc:10261, hgnc:1100 ;
+\t:geneDetectedByNER hgnc:1100 .
+
+aop.events:2 a aopo:KeyEvent ;
+\t:geneDetectedByRegex hgnc:10261 ;
+\t:geneDetectedByNER hgnc:1100 .
+
+aop.relationships:3 a aopo:KeyEventRelationship ;
+\t:geneDetectedByRegex hgnc:10261, hgnc:1100 ;
+\t:geneDetectedByNER hgnc:1100 .
+"""
+
+
+# --- Parsing and ranking ---------------------------------------------------
+
+def test_parse_separates_the_two_detectors():
+    regex_hits, ner_hits = parse_detector_sets(TTL)
+
+    assert regex_hits['10261'] == {
+        'aop.events:1', 'aop.events:2', 'aop.relationships:3',
+    }
+    assert '10261' not in ner_hits
+    assert len(ner_hits['1100']) == 3
+
+
+def test_ranking_surfaces_the_unconfirmed_gene():
+    regex_hits, ner_hits = parse_detector_sets(TTL)
+    ranked = rank_candidates(regex_hits, ner_hits,
+                             min_regex_entities=3, max_agreement=0.10)
+
+    assert [c['gene'] for c in ranked] == ['hgnc:10261']
+    assert ranked[0]['ner_confirmed'] == 0
+
+
+def test_confirmed_gene_is_not_flagged():
+    """A gene both detectors agree on is not a collision candidate."""
+    regex_hits, ner_hits = parse_detector_sets(TTL)
+    ranked = rank_candidates(regex_hits, ner_hits,
+                             min_regex_entities=1, max_agreement=0.10)
+
+    assert 'hgnc:1100' not in [c['gene'] for c in ranked]
+
+
+def test_min_entity_threshold_filters_rare_genes():
+    regex_hits, ner_hits = parse_detector_sets(TTL)
+    assert rank_candidates(regex_hits, ner_hits,
+                           min_regex_entities=10, max_agreement=0.10) == []
+
+
+def test_ranking_is_ordered_by_regex_entity_count():
+    regex_hits = {'a': {1, 2, 3}, 'b': {1, 2, 3, 4, 5}, 'c': {1}}
+    ranked = rank_candidates(regex_hits, {'z': {1}},
+                             min_regex_entities=1, max_agreement=0.10)
+    assert [c['gene'] for c in ranked] == ['hgnc:b', 'hgnc:a', 'hgnc:c']
+
+
+# --- Stressor filter -------------------------------------------------------
+
+def stressor(text, token):
+    start = text.index(token)
+    return _is_stressor_mention(text, start, start + len(token))
+
+
+@pytest.mark.parametrize('text,token', [
+    ('BPA exposure altered receptor expression', 'BPA'),
+    ('DBP treatment reduced testosterone', 'DBP'),
+    ('Rats exposed to BPA showed effects', 'BPA'),
+    ('following treatment with DBP', 'DBP'),
+    ('altered in response to PFAS exposure', 'PFAS'),
+])
+def test_abbreviation_next_to_exposure_language_is_a_stressor(text, token):
+    assert stressor(text, token)
+
+
+@pytest.mark.parametrize('text,token', [
+    # Modifier, not the administered thing -- this guard recovered 8 TPO matches.
+    ('maternal administration of TPO inhibitors', 'TPO'),
+    ('after exposure to TPO inhibitors and deiodinase', 'TPO'),
+    ('exposure to AR antagonists', 'AR'),
+    # Not exposure language at all.
+    ('AR receptor antagonism reduces signalling', 'AR'),
+    ('Hepatic TH gene expression fell', 'TH'),
+])
+def test_modifier_and_plain_mentions_are_not_stressors(text, token):
+    assert not stressor(text, token)
+
+
+def test_full_protein_names_are_exempt():
+    """'leptin treatment' is about leptin; an earlier revision discarded it."""
+    assert not stressor('leptin treatment increased satiety', 'leptin')
+    assert not stressor('insulin treatment lowered glucose', 'insulin')
+
+
+def test_only_the_stressor_is_dropped_from_a_mixed_sentence():
+    """The positional test is what makes this safe.
+
+    'exposure' is in range for both tokens, but only BPA is directly followed
+    by it -- a window-wide test would discard the legitimate AR match too.
+    """
+    spec = {'644': ['AR', 'androgen receptor'], '1090': ['DST', 'dystonin', 'BPA']}
+    found = set(_map_genes_in_text(
+        'AR expression was measured after BPA exposure',
+        spec, [], None, None, {'644': 'AR', '1090': 'DST'},
+    ))
+    assert found == {'hgnc:644'}


### PR DESCRIPTION
Closes #109.

Finding alias collisions was manual — someone had to notice that `ROS` was matching ROS1 and add it to the stoplist. `scripts/detector_disagreement.py` ranks genes the dictionary asserts on many entities that BERN2 never confirms, which is overwhelmingly a collision: a context-aware model declines exactly what a context-free string match cannot.

Run against the pre-fix `97191db` release it puts **ROS1 first and TBATA second** — the two clearest collisions, recovered independently of the manual audit that originally found them.

**Advisory only.** Uploaded as a QC artifact, never blocking. NER silence does not prove a false positive: BERN2 has its own recall gaps and has had zero-output weeks, and it cannot see collisions both detectors make.

## One correction to the issue

The issue reports **9 of 10** known collisions still firing after #107. Measured against the **full** dictionary it is **1 of 10**.

The reported test used isolated per-gene dictionaries, which bypasses the ownership resolution #107 added. With the real dictionary `TPO` resolves to thyroid peroxidase, `AR` to the androgen receptor, `EMT`/`ERK`/`p38`/`ALP` are filtered by the short-token rule, and `LPS` isn't delimiter-bounded in `LPS-induced`.

## The remaining case is real

`BPA` (bisphenol A) is an alias of **DST**, and `DBP` (dibutyl phthalate) is the approved symbol of **D-box binding protein** — two of the most-studied stressors in AOP-Wiki, read as gene mentions. A token of ≤4 characters sitting **immediately** beside exposure language is now treated as an administered substance.

Two guards, both added because measurement showed the naive rule losing true positives:

| guard | why |
|---|---|
| **Position, not proximity** | In *"AR expression was measured after BPA exposure"* `exposure` is in range of both tokens, but only BPA is directly followed by it. A window-wide test discarded the legitimate AR match. |
| **A following head noun cancels it** | In *"exposure to TPO inhibitors"* the administered thing is the inhibitor; TPO modifies it. Without this the rule threw away **8 valid thyroid-peroxidase matches**. |

Full protein names are exempt — an earlier revision discarded *"leptin treatment"* and *"insulin treatment"*, which are genuine mentions of those gene products.

## Measured

4,057 → 4,049 associations, **no gene lost entirely**. All eight removals reviewed individually: **BPA→DST** and **PFAS** (per/polyfluoroalkyl substances, colliding with phosphoribosylformylglycinamidine synthase) are the clear wins; one TNF case is genuinely debatable, since TNF is an administered cytokine.

The ranking on the current published release now reports **6 candidates over 72 pairs**, down from **42 candidates over 918** pre-fix.

17 new tests; full unit suite **386 passed**. No data files touched.
